### PR TITLE
Payment receiver is determined dynamically at payment time

### DIFF
--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -271,7 +271,7 @@ const CryptoPaymentButton = ({
     }, [openConnectModal, isConnected]);
 
     //RETURNS TRANSACTION ID
-    const makePayment = async () => {
+    const makePayment = async (receiver: string) => {
         try {
             const session = cart.payment_session as PaymentSession;
             const provider = new ethers.BrowserProvider(
@@ -281,6 +281,7 @@ const CryptoPaymentButton = ({
             const signer = await provider.getSigner();
 
             console.log('payer: ', signer.address);
+            console.log('receiver: ', receiver);
 
             const switchClient: SwitchClient = new SwitchClient(
                 provider,
@@ -291,7 +292,7 @@ const CryptoPaymentButton = ({
                     amount: session.amount,
                     id: 1, 
                     payer: signer.address ?? "", 
-                    receiver: "0xcEa845CA58C8dD4369810c3b5168C49Faa34E6F3"
+                    receiver: receiver
                 }
             );
 
@@ -305,8 +306,8 @@ const CryptoPaymentButton = ({
         return '';
     };
 
-    const onPaymentCompleted = async (transaction_id: string) => {
-        await placeOrder(transaction_id).catch(() => {
+    const onPaymentCompleted = async (transactionId: string) => {
+        await placeOrder(transactionId).catch(() => {
             setErrorMessage('An error occurred, please try again.');
             setSubmitting(false);
         });
@@ -315,16 +316,21 @@ const CryptoPaymentButton = ({
     const session = cart.payment_session as PaymentSession;
     
     const handlePayment = async () => {
-        setSubmitting(true);
+        try
+        {
+            setSubmitting(true);
 
-        //here connect wallet and sign in, if not connected
-        connect();
-        
-        //get the transaction id from payment 
-        const transaction_id: string = await makePayment();
+            //here connect wallet and sign in, if not connected
+            connect();
 
-        //pass the transaction id back to the provider
-        onPaymentCompleted(transaction_id);
+            //get the transaction id from payment 
+            const transactionId: string = await makePayment(session.data.wallet_address.toString());
+
+            //pass the transaction id back to the provider
+            if (transactionId?.length)
+                onPaymentCompleted(transactionId);
+        }
+        catch(e) { console.error(e); }
     };
 
     return (

--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -290,7 +290,7 @@ const CryptoPaymentButton = ({
             ); //TODO: get contract address dynamically
             const output: ITransactionOutput = await switchClient.placeSinglePayment({
                     amount: session.amount,
-                    id: 1, 
+                    id: Math.floor(Math.random() * 9999) + 1, 
                     payer: signer.address ?? "", 
                     receiver: receiver
                 }

--- a/hamza-server/src/index.d.ts
+++ b/hamza-server/src/index.d.ts
@@ -1,5 +1,7 @@
 // We're extending CORE Medusa models here
 
+import { Store } from "@medusajs/medusa";
+
 export declare module "@medusajs/medusa/dist/models/product" {
   declare interface Product {
     customAttribute: string;
@@ -34,6 +36,7 @@ export declare module "@medusajs/medusa/dist/models/store" {
 
 export declare module "@medusajs/medusa/dist/models/product" {
   declare interface Product {
+    store?: Store;
     store_id: string;
   }
 }

--- a/hamza-server/src/models/store.ts
+++ b/hamza-server/src/models/store.ts
@@ -1,4 +1,4 @@
-import { Entity, OneToOne, JoinColumn } from "typeorm"
+import { Entity, OneToOne, JoinColumn, Column } from "typeorm"
 import { Store as MedusaStore } from "@medusajs/medusa"
 import { User } from './user';
 
@@ -7,4 +7,7 @@ export class Store extends MedusaStore {
   @OneToOne(() => User)
   @JoinColumn({ name: "owner_id" })
   owner?: User;
+  
+  @Column("owner_id")
+  owner_id?: string;
 }

--- a/hamza-server/src/models/user.ts
+++ b/hamza-server/src/models/user.ts
@@ -1,4 +1,5 @@
 import {
+    Column,
   Entity,
   OneToOne,
 } from "typeorm";
@@ -18,6 +19,7 @@ export class User extends MedusaUser {
   @OneToOne(() => Store, (store) => store.owner)
   store?: Store;
 
+  @Column()
   wallet_address: string;
   // email?: string;
   // password_hash?: string;

--- a/hamza-server/src/services/crypto-payment-provider.ts
+++ b/hamza-server/src/services/crypto-payment-provider.ts
@@ -1,17 +1,19 @@
 import { 
     AbstractPaymentProcessor,
+    Cart,
+    CartService,
     PaymentProcessorContext,
     PaymentProcessorError,
     PaymentProcessorSessionResponse,
-    PaymentSessionStatus
+    PaymentSessionStatus,
 } from '@medusajs/medusa';
 import { PaymentIntentOptions } from 'medusa-payment-stripe'; //TODO: need? 
 import { ethers, TransactionResponse } from 'ethers';
 
-async function verifyPaymentTransactionId(transaction_id: any) : Promise<boolean> {
+async function verifyPaymentTransactionId(transactionId: any) : Promise<boolean> {
     try {
         const provider = new ethers.JsonRpcProvider('https://rpc.sepolia.org');
-        const tx: TransactionResponse = await provider.getTransaction(transaction_id); 
+        const tx: TransactionResponse = await provider.getTransaction(transactionId); 
         if (tx) {
             //TODO: more verification is needed 
             //tx.from
@@ -31,19 +33,18 @@ async function verifyPaymentTransactionId(transaction_id: any) : Promise<boolean
  */
 class CryptoPaymentService extends AbstractPaymentProcessor {
     static identifier = 'crypto';
+    cartService: CartService;
 
     constructor(container, config) {
-        console.log('CryptoPaymentService::container');
-        console.log(container);
         console.log('CryptoPaymentService::config');
         console.log(config);
         super(container, config);
+        this.cartService = container.cartService;
     }
 
     async capturePayment(paymentSessionData: Record<string, unknown>): Promise<PaymentProcessorError | PaymentProcessorSessionResponse['session_data']> {
         console.log('CryptoPaymentService: capturePayment');
         console.log(paymentSessionData);
-        console.log(super.container);
         return {
             session_data: paymentSessionData
         };
@@ -92,15 +93,21 @@ class CryptoPaymentService extends AbstractPaymentProcessor {
         console.log('CryptoPaymentService: initiatePayment');
         console.log(context);
 
+        //get the store id
+        let walletAddresses: string[] = [];
+        if (context.resource_id) {
+            walletAddresses = await this._getCartWalletAddresses(context.resource_id.toString());
+        }
+
         const intentRequestData = this.getPaymentIntentOptions();
         const { email, currency_code, amount, resource_id, customer } = context;
         
         //if there is a tx id, verify that it's legit
         let payment_status = 'ok'; 
         if (context?.context?.transaction_id) {
-            const transaction_id = context.context.transaction_id;
-            console.log('got transaction_id: ', transaction_id);
-            if (!await verifyPaymentTransactionId(transaction_id)) {
+            const transactionId = context.context.transaction_id;
+            console.log('got transaction_id: ', transactionId);
+            if (!await verifyPaymentTransactionId(transactionId)) {
                 //TODO: need a better system to communicate payment failure 
                 payment_status = 'failed';
             }
@@ -110,6 +117,7 @@ class CryptoPaymentService extends AbstractPaymentProcessor {
             amount: Math.round(100),
             currency: 'USD',
             notes: { resource_id },
+            wallet_address: walletAddresses.length ?? walletAddresses[0],
             payment: {
                 capture: 'manual',
                 payment_status: payment_status,
@@ -181,6 +189,36 @@ class CryptoPaymentService extends AbstractPaymentProcessor {
                 'sessionId': sessionId
             }
         };
+    }
+    
+    private async _getCartWalletAddresses(cartId: string) : Promise<string[]> {
+        const output: string[] = [];
+
+        try {
+            const productIds: string[] = [];
+            const promises: Promise<string>[] = [];
+
+            //get cart; cart has items, items have variants, variants have products,
+            // products have stores, stores have owners, owners have wallets
+            const cart: Cart = await this.cartService.retrieve(
+                cartId, { relations: ["items.variant.product.store.owner"]}
+            );
+            
+            //add unique wallet addresses to output
+            if (cart && cart.items) {
+                cart.items.forEach(i => {
+                    const wallet: string = i.variant?.product?.store?.owner?.wallet_address;
+                    if (wallet && output.findIndex(s => s === wallet) < 0) {
+                        output.push(wallet);
+                    }
+                });
+            }
+        }
+        catch(e) {
+            console.error(e);
+        }
+        
+        return output;
     }
 }
 

--- a/hamza-server/src/services/crypto-payment-provider.ts
+++ b/hamza-server/src/services/crypto-payment-provider.ts
@@ -112,12 +112,14 @@ class CryptoPaymentService extends AbstractPaymentProcessor {
                 payment_status = 'failed';
             }
         }
+        
+        const addr = walletAddresses.length ? walletAddresses[0] : ''; //TODO: return whole array 
 
         const session_data: any = {
             amount: Math.round(100),
             currency: 'USD',
             notes: { resource_id },
-            wallet_address: walletAddresses.length ?? walletAddresses[0],
+            wallet_address: addr,
             payment: {
                 capture: 'manual',
                 payment_status: payment_status,


### PR DESCRIPTION
A couple of changes were necessary to get the server side at checkout time to determine the correct wallet address to use, based on the wallet address associated with the stores from which products are being purchased, then to pass that back to the client so that it could be passed to the Switch as the receiver of funds. 

- Models had to be adjusted to appease TypeORM standards, so that service queries could easily retrieve the store via the Product, and the User via the Store with the minimum amount of querying. 
- The Crypto payment processor was modified so that it would make those queries to retrieve the appropriate wallet addresses, and pass them back to the client at the start of the payment session. 
- The Crypto payment button and related code was modified to retrieve the wallet address from the payment processor, and use that instead of a hard-coded one, when calling the Switch client. 

Note: actually the wallet addresses should be passed back as an associative array, each associated with a set of products/cart items. But since the mechanism to break up an order in that way hasn't been developed yet, the processor is now only sending back the first address in the array. 
