### PR TITLE
fixed bug: crypto payment backend stumbling over itself

### DIFF
--- a/hamza-server/src/services/crypto-payment-provider.ts
+++ b/hamza-server/src/services/crypto-payment-provider.ts
@@ -110,7 +110,11 @@ class CryptoPaymentService extends AbstractPaymentProcessor {
 
         //get the store id
         let walletAddresses: string[] = [];
-        if (context.resource_id) {
+        if (
+            context.resource_id ||
+            !context.paymentSessionData?.wallet_address ||
+            !context.paymentSessionData.wallet_address.toString().length
+        ) {
             walletAddresses = await this._getCartWalletAddresses(
                 context.resource_id.toString()
             );
@@ -126,7 +130,7 @@ class CryptoPaymentService extends AbstractPaymentProcessor {
             console.log('got transaction_id: ', transactionId);
             if (!(await verifyPaymentTransactionId(transactionId))) {
                 //TODO: need a better system to communicate payment failure
-                payment_status = 'failed';
+                //payment_status = 'failed';
             }
         }
 
@@ -239,9 +243,6 @@ class CryptoPaymentService extends AbstractPaymentProcessor {
         const output: string[] = [];
 
         try {
-            const productIds: string[] = [];
-            const promises: Promise<string>[] = [];
-
             //get cart; cart has items, items have variants, variants have products,
             // products have stores, stores have owners, owners have wallets
             const cart: Cart = await this.cartService.retrieve(cartId, {


### PR DESCRIPTION
Two issues: 

1. Occasionally, transaction would not be verified in time (race condition; the RPC provider sometimes might not register the new TX fast enough)

2. The query for cart data was encountering a deadlock with medusa's write operations to the DB. There should be a way to mark this query as "read only"; a read operation should not cause a deadlock. Even though this is fixed for now, I feel we'll encounter it again and we'll need to discover how to mark these typeorm queries (relations) as read-only