### PR TITLE
Staging payment order crud

### DIFF
--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -142,9 +142,9 @@ const CryptoPaymentButton = ({
             console.log(output);
             return {
                 transaction_id: output.transaction_id,
-                payer_address: 'temp',
-                receiver_address: 'temp',
-                escrow_contract_address: 'temp',
+                payer_address: output.receipt.from,
+                receiver_address: 'tbd', // assume this needs to be the array of switchInput[i].payments[j].reciever
+                escrow_contract_address: output.receipt.to,
             };
         } catch (e) {
             console.error('error has occured during transaction', e);

--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -142,9 +142,9 @@ const CryptoPaymentButton = ({
             console.log(output);
             return {
                 transaction_id: output.transaction_id,
-                payer_address: '',
-                receiver_address: '',
-                escrow_contract_address: '',
+                payer_address: 'temp',
+                receiver_address: 'temp',
+                escrow_contract_address: 'temp',
             };
         } catch (e) {
             console.error('error has occured during transaction', e);

--- a/hamza-server/src/migrations/1907365738273-MultiVendorOrder.ts
+++ b/hamza-server/src/migrations/1907365738273-MultiVendorOrder.ts
@@ -6,9 +6,6 @@ export class MultiVendorOrder1907365738273 implements MigrationInterface {
             `ALTER TABLE "order" ADD COLUMN "store_id" VARCHAR NULL`
         );
         await queryRunner.query(
-            `ALTER TABLE "order" ADD COLUMN "transaction_id" VARCHAR NULL`
-        );
-        await queryRunner.query(
             `ALTER TABLE "order" ADD CONSTRAINT "FK_Order_Store" FOREIGN KEY ("store_id") REFERENCES "store"("id") ON DELETE SET NULL ON UPDATE CASCADE`
         );
         await queryRunner.query(
@@ -19,9 +16,6 @@ export class MultiVendorOrder1907365738273 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
             `ALTER TABLE "order" DROP CONSTRAINT "FK_Order_Store"`
-        );
-        await queryRunner.query(
-            `ALTER TABLE "order" DROP COLUMN "transaction_id"`
         );
         await queryRunner.query(`ALTER TABLE "order" DROP COLUMN "store_id"`);
         await queryRunner.query(

--- a/hamza-server/src/models/order.ts
+++ b/hamza-server/src/models/order.ts
@@ -11,7 +11,4 @@ export class Order extends MedusaOrder {
 
     @Column('store_id')
     store_id?: string;
-
-    @Column()
-    transaction_id?: string;
 }

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -83,12 +83,6 @@ export default class OrderService extends MedusaOrderService {
         return result;
     }
 
-    async setCartId (payment: Payment, update: Partial<Payment>): Promise<Payment> {
-        console.log(`payment: ${payment}`);
-        const result = await this.paymentRepository_.save({id: payment.id, ...update})
-        return result
-    }
-
     async finalizeCheckout(
         cart_id: string,
         transaction_id: string,

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -69,18 +69,24 @@ export default class OrderService extends MedusaOrderService {
         });
     }
 
-    async updateOrder(orderId: string, update: Partial<Order>): Promise<Order> {
+    async updateOrderAfterTransaction(orderId: string, update: Partial<Order>): Promise<Order> {
         console.log('Received update for order:', orderId, update);
         const result = await this.orderRepository_.save({ id: orderId, ...update });
         console.log('Update result:', result);
         return result;
     }
 
-    async updatePayment(paymentId: string, update: Partial<Payment>): Promise<Payment> {
+    async updatePaymentAfterTransaction(paymentId: string, update: Partial<Payment>): Promise<Payment> {
         console.log('Received update for payment:', paymentId, update);
         const result = await this.paymentRepository_.save({ id: paymentId, ...update });
         console.log('Update result:', result);
         return result;
+    }
+
+    async setCartId (payment: Payment, update: Partial<Payment>): Promise<Payment> {
+        console.log(`payment: ${payment}`);
+        const result = await this.paymentRepository_.save({id: payment.id, ...update})
+        return result
     }
 
     async finalizeCheckout(
@@ -106,14 +112,12 @@ export default class OrderService extends MedusaOrderService {
 
         //update orders with transaction info
         orders.forEach((o, i) => {
-            console.log(o);
-            promises.push(this.updateOrder(o.id, { transaction_id }));
+            promises.push(this.updateOrderAfterTransaction(o.id, { transaction_id }));
         });
 
         //update payments with transaction info
         payments.forEach((p, i) => {
-            console.log(p);
-            promises.push(this.updatePayment(p.id, {
+            promises.push(this.updatePaymentAfterTransaction(p.id, {
                 transaction_id, // Remove from here and from model
                 receiver_address,
                 payer_address,

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -69,17 +69,8 @@ export default class OrderService extends MedusaOrderService {
         });
     }
 
-    async updateOrderAfterTransaction(orderId: string, update: Partial<Order>): Promise<Order> {
-        console.log('Received update for order:', orderId, update);
-        const result = await this.orderRepository_.save({ id: orderId, ...update });
-        console.log('Update result:', result);
-        return result;
-    }
-
     async updatePaymentAfterTransaction(paymentId: string, update: Partial<Payment>): Promise<Payment> {
-        console.log('Received update for payment:', paymentId, update);
         const result = await this.paymentRepository_.save({ id: paymentId, ...update });
-        console.log('Update result:', result);
         return result;
     }
 
@@ -104,15 +95,12 @@ export default class OrderService extends MedusaOrderService {
 
         const promises: Promise<Order | Payment>[] = [];
 
-        //update orders with transaction info
-        orders.forEach((o, i) => {
-            promises.push(this.updateOrderAfterTransaction(o.id, { transaction_id }));
-        });
+        
 
         //update payments with transaction info
         payments.forEach((p, i) => {
             promises.push(this.updatePaymentAfterTransaction(p.id, {
-                transaction_id, // Remove from here and from model
+                transaction_id, 
                 receiver_address,
                 payer_address,
                 escrow_contract_address,

--- a/hamza-server/src/strategies/cart-completion.ts
+++ b/hamza-server/src/strategies/cart-completion.ts
@@ -10,7 +10,6 @@ import {
     Payment,
 } from '@medusajs/medusa';
 import OrderService from '../services/order';
-import { OrderRepository } from '@medusajs/medusa/dist/repositories/order';
 import { PaymentService } from '@medusajs/medusa/dist/services';
 import { PaymentDataInput } from '@medusajs/medusa/dist/services/payment';
 import { RequestContext } from '@medusajs/medusa/dist/types/request';
@@ -108,6 +107,13 @@ class CartCompletionStrategy extends AbstractCartCompletionStrategy {
 
             //update payments with order ids
             await this.updatePaymentsWithOrderId(payments, orders);
+
+
+            // Adding CartId in the payments table is impossible, currently, 
+            // it's a foreign key of cart which is unique, 
+            // this uniqueness constraint is enforced on the payment table
+
+            // await this.updatePaymentsWithCartID(payments, cartId);
 
             //create & return the response
             const response: CartCompletionResponse = {
@@ -279,6 +285,33 @@ class CartCompletionStrategy extends AbstractCartCompletionStrategy {
         }
         await Promise.all(promises);
     }
+
+    // private async updatePaymentsWithCartID(
+    //     payments: Payment[],
+    //     cart_id: string
+    // ): Promise<void> {
+    //     console.log('--------------------------------------------')
+    //     console.log('CartId is happening')
+    //     console.log('--------------------------------------------')
+    //     const promises: Promise<Payment>[] = [];
+    //     for (let n = 0; n < payments.length; n++) {
+    //         if (cart_id) {
+    //             console.log(payments[n])
+    //             console.log(cart_id)
+    //             payments[n].cart_id = cart_id;
+    //             console.log(payments[n])
+    //             promises.push(
+    //                 this.orderService.setCartId(payments[n], { cart_id })
+    //             );
+    //         }
+    //     }
+    //     try{
+    //         await Promise.all(promises);
+    //     }
+    //     catch(e){
+    //         console.log(e)
+    //     }
+    // }
 }
 
 export default CartCompletionStrategy;

--- a/hamza-server/src/strategies/cart-completion.ts
+++ b/hamza-server/src/strategies/cart-completion.ts
@@ -282,33 +282,6 @@ class CartCompletionStrategy extends AbstractCartCompletionStrategy {
         }
         await Promise.all(promises);
     }
-
-    // private async updatePaymentsWithCartID(
-    //     payments: Payment[],
-    //     cart_id: string
-    // ): Promise<void> {
-    //     console.log('--------------------------------------------')
-    //     console.log('CartId is happening')
-    //     console.log('--------------------------------------------')
-    //     const promises: Promise<Payment>[] = [];
-    //     for (let n = 0; n < payments.length; n++) {
-    //         if (cart_id) {
-    //             console.log(payments[n])
-    //             console.log(cart_id)
-    //             payments[n].cart_id = cart_id;
-    //             console.log(payments[n])
-    //             promises.push(
-    //                 this.orderService.setCartId(payments[n], { cart_id })
-    //             );
-    //         }
-    //     }
-    //     try{
-    //         await Promise.all(promises);
-    //     }
-    //     catch(e){
-    //         console.log(e)
-    //     }
-    // }
 }
 
 export default CartCompletionStrategy;

--- a/hamza-server/src/strategies/cart-completion.ts
+++ b/hamza-server/src/strategies/cart-completion.ts
@@ -108,12 +108,9 @@ class CartCompletionStrategy extends AbstractCartCompletionStrategy {
             //update payments with order ids
             await this.updatePaymentsWithOrderId(payments, orders);
 
-
             // Adding CartId in the payments table is impossible, currently, 
             // it's a foreign key of cart which is unique, 
             // this uniqueness constraint is enforced on the payment table
-
-            // await this.updatePaymentsWithCartID(payments, cartId);
 
             //create & return the response
             const response: CartCompletionResponse = {


### PR DESCRIPTION
properly writing to payment table
removed tx_id from order table
investigated the viability of adding cart_id to payment table
I think it's not possible, but it is accessable through order, which is related to payment, so maybe redundant anyway?
other suggestions welcome. 