### PR TITLE
Selecting Prices for Checkout

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -98,15 +98,21 @@ export async function addItem({
     cartId,
     variantId,
     quantity,
+    currencyCode,
 }: {
     cartId: string;
     variantId: string;
     quantity: number;
+    currencyCode: string;
 }) {
     const headers = getMedusaHeaders(['cart']);
 
     return medusaClient.carts.lineItems
-        .create(cartId, { variant_id: variantId, quantity }, headers)
+        .create(
+            cartId,
+            { variant_id: variantId, quantity /*currency_code: currencyCode*/ },
+            headers
+        )
         .then(({ cart }) => cart)
         .catch((err) => {
             console.log(err);
@@ -511,7 +517,6 @@ export async function getProductsList({
         .catch((err) => {
             throw err;
         });
-
 
     const transformedProducts = products.map((product) => {
         return transformProductPreview(product, region!);

--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -1,20 +1,20 @@
-"use server"
+'use server';
 
-import { LineItem } from "@medusajs/medusa"
-import { omit } from "lodash"
-import { revalidateTag } from "next/cache"
-import { cookies } from "next/headers"
+import { LineItem } from '@medusajs/medusa';
+import { omit } from 'lodash';
+import { revalidateTag } from 'next/cache';
+import { cookies } from 'next/headers';
 
 import {
-  addItem,
-  createCart,
-  getCart,
-  getProductsById,
-  removeItem,
-  updateCart,
-  updateItem,
-} from "@lib/data"
-import { getRegion } from "app/actions"
+    addItem,
+    createCart,
+    getCart,
+    getProductsById,
+    removeItem,
+    updateCart,
+    updateItem,
+} from '@lib/data';
+import { getRegion } from 'app/actions';
 
 /**
  * Retrieves the cart based on the cartId cookie
@@ -24,171 +24,185 @@ import { getRegion } from "app/actions"
  * const cart = await getOrSetCart()
  */
 export async function getOrSetCart(countryCode: string) {
-  const cartId = cookies().get("_medusa_cart_id")?.value
-  let cart
+    const cartId = cookies().get('_medusa_cart_id')?.value;
+    let cart;
 
-  if (cartId) {
-    cart = await getCart(cartId).then((cart) => cart)
-  }
+    if (cartId) {
+        cart = await getCart(cartId).then((cart) => cart);
+    }
 
-  const region = await getRegion(countryCode)
+    const region = await getRegion(countryCode);
 
-  if (!region) {
-    return null
-  }
+    if (!region) {
+        return null;
+    }
 
-  const region_id = region.id
+    const region_id = region.id;
 
-  if (!cart) {
-    cart = await createCart({ region_id }).then((res) => res)
-    cart && cookies().set("_medusa_cart_id", cart.id)
-    revalidateTag("cart")
-  }
+    if (!cart) {
+        cart = await createCart({ region_id }).then((res) => res);
+        cart && cookies().set('_medusa_cart_id', cart.id);
+        revalidateTag('cart');
+    }
 
-  if (cart && cart?.region_id !== region_id) {
-    await updateCart(cart.id, { region_id })
-    revalidateTag("cart")
-  }
+    if (cart && cart?.region_id !== region_id) {
+        await updateCart(cart.id, { region_id });
+        revalidateTag('cart');
+    }
 
-  return cart
+    return cart;
 }
 
 export async function retrieveCart() {
-  const cartId = cookies().get("_medusa_cart_id")?.value
+    const cartId = cookies().get('_medusa_cart_id')?.value;
 
-  if (!cartId) {
-    return null
-  }
+    if (!cartId) {
+        return null;
+    }
 
-  try {
-    const cart = await getCart(cartId).then((cart) => cart)
-    return cart
-  } catch (e) {
-    console.log(e)
-    return null
-  }
+    try {
+        const cart = await getCart(cartId).then((cart) => cart);
+        return cart;
+    } catch (e) {
+        console.log(e);
+        return null;
+    }
 }
 
 export async function addToCart({
-  variantId,
-  quantity,
-  countryCode,
+    variantId,
+    quantity,
+    countryCode,
+    currencyCode,
 }: {
-  variantId: string
-  quantity: number
-  countryCode: string
+    variantId: string;
+    quantity: number;
+    countryCode: string;
+    currencyCode: string;
 }) {
-  const cart = await getOrSetCart(countryCode).then((cart) => cart)
+    const cart = await getOrSetCart(countryCode).then((cart) => cart);
 
-  if (!cart) {
-    return "Missing cart ID"
-  }
+    if (!cart) {
+        return 'Missing cart ID';
+    }
 
-  if (!variantId) {
-    return "Missing product variant ID"
-  }
+    if (!variantId) {
+        return 'Missing product variant ID';
+    }
 
-  try {
-    await addItem({ cartId: cart.id, variantId, quantity })
-    revalidateTag("cart")
-  } catch (e) {
-    return "Error adding item to cart"
-  }
+    try {
+        await addItem({
+            cartId: cart.id,
+            variantId,
+            quantity,
+            currencyCode,
+        });
+        revalidateTag('cart');
+    } catch (e) {
+        return 'Error adding item to cart';
+    }
 }
 
 export async function updateLineItem({
-  lineId,
-  quantity,
+    lineId,
+    quantity,
 }: {
-  lineId: string
-  quantity: number
+    lineId: string;
+    quantity: number;
 }) {
-  const cartId = cookies().get("_medusa_cart_id")?.value
+    const cartId = cookies().get('_medusa_cart_id')?.value;
 
-  if (!cartId) {
-    return "Missing cart ID"
-  }
+    if (!cartId) {
+        return 'Missing cart ID';
+    }
 
-  if (!lineId) {
-    return "Missing lineItem ID"
-  }
+    if (!lineId) {
+        return 'Missing lineItem ID';
+    }
 
-  if (!cartId) {
-    return "Missing cart ID"
-  }
+    if (!cartId) {
+        return 'Missing cart ID';
+    }
 
-  try {
-    await updateItem({ cartId, lineId, quantity })
-    revalidateTag("cart")
-  } catch (e: any) {
-    return e.toString()
-  }
+    try {
+        await updateItem({ cartId, lineId, quantity });
+        revalidateTag('cart');
+    } catch (e: any) {
+        return e.toString();
+    }
 }
 
 export async function deleteLineItem(lineId: string) {
-  const cartId = cookies().get("_medusa_cart_id")?.value
+    const cartId = cookies().get('_medusa_cart_id')?.value;
 
-  if (!cartId) {
-    return "Missing cart ID"
-  }
+    if (!cartId) {
+        return 'Missing cart ID';
+    }
 
-  if (!lineId) {
-    return "Missing lineItem ID"
-  }
+    if (!lineId) {
+        return 'Missing lineItem ID';
+    }
 
-  if (!cartId) {
-    return "Missing cart ID"
-  }
+    if (!cartId) {
+        return 'Missing cart ID';
+    }
 
-  try {
-    await removeItem({ cartId, lineId })
-    revalidateTag("cart")
-  } catch (e) {
-    return "Error deleting line item"
-  }
+    try {
+        await removeItem({ cartId, lineId });
+        revalidateTag('cart');
+    } catch (e) {
+        return 'Error deleting line item';
+    }
 }
 
+type ExtendedLineItem = LineItem & {
+    currency_code?: string;
+};
+
 export async function enrichLineItems(
-  lineItems: LineItem[],
-  regionId: string
+    lineItems: LineItem[],
+    regionId: string
 ): Promise<
-  | Omit<LineItem, "beforeInsert" | "beforeUpdate" | "afterUpdateOrLoad">[]
-  | undefined
+    | Omit<
+          ExtendedLineItem,
+          'beforeInsert' | 'beforeUpdate' | 'afterUpdateOrLoad'
+      >[]
+    | undefined
 > {
-  // Prepare query parameters
-  const queryParams = {
-    ids: lineItems.map((lineItem) => lineItem.variant.product_id),
-    regionId: regionId,
-  }
+    // Prepare query parameters
+    const queryParams = {
+        ids: lineItems.map((lineItem) => lineItem.variant.product_id),
+        regionId: regionId,
+    };
 
-  // Fetch products by their IDs
-  const products = await getProductsById(queryParams)
+    // Fetch products by their IDs
+    const products = await getProductsById(queryParams);
 
-  // If there are no line items or products, return an empty array
-  if (!lineItems?.length || !products) {
-    return []
-  }
-
-  // Enrich line items with product and variant information
-
-  const enrichedItems = lineItems.map((item) => {
-    const product = products.find((p) => p.id === item.variant.product_id)
-    const variant = product?.variants.find((v) => v.id === item.variant_id)
-
-    // If product or variant is not found, return the original item
-    if (!product || !variant) {
-      return item
+    // If there are no line items or products, return an empty array
+    if (!lineItems?.length || !products) {
+        return [];
     }
 
-    // If product and variant are found, enrich the item
-    return {
-      ...item,
-      variant: {
-        ...variant,
-        product: omit(product, "variants"),
-      },
-    }
-  }) as LineItem[]
+    // Enrich line items with product and variant information
 
-  return enrichedItems
+    const enrichedItems = lineItems.map((item) => {
+        const product = products.find((p) => p.id === item.variant.product_id);
+        const variant = product?.variants.find((v) => v.id === item.variant_id);
+
+        // If product or variant is not found, return the original item
+        if (!product || !variant) {
+            return item;
+        }
+
+        // If product and variant are found, enrich the item
+        return {
+            ...item,
+            variant: {
+                ...variant,
+                product: omit(product, 'variants'),
+            },
+        };
+    }) as LineItem[];
+
+    return enrichedItems;
 }

--- a/hamza-client/src/modules/cart/components/item/index.tsx
+++ b/hamza-client/src/modules/cart/components/item/index.tsx
@@ -15,8 +15,12 @@ import { useState } from 'react';
 import ErrorMessage from '@modules/checkout/components/error-message';
 import LocalizedClientLink from '@modules/common/components/localized-client-link';
 
+type ExtendedLineItem = LineItem & {
+    currency_code?: string;
+};
+
 type ItemProps = {
-    item: Omit<LineItem, 'beforeInsert'>;
+    item: Omit<ExtendedLineItem, 'beforeInsert'>;
     region: Region;
     type?: 'full' | 'preview';
 };

--- a/hamza-client/src/modules/cart/templates/items.tsx
+++ b/hamza-client/src/modules/cart/templates/items.tsx
@@ -4,8 +4,12 @@ import { Heading, Table } from '@medusajs/ui';
 import Item from '@modules/cart/components/item';
 import SkeletonLineItem from '@modules/skeletons/components/skeleton-line-item';
 
+type ExtendedLineItem = LineItem & {
+    currency_code?: string;
+};
+
 type ItemsTemplateProps = {
-    items?: Omit<LineItem, 'beforeInsert'>[];
+    items?: Omit<ExtendedLineItem, 'beforeInsert'>[];
     region?: Region;
 };
 

--- a/hamza-client/src/modules/cart/templates/preview.tsx
+++ b/hamza-client/src/modules/cart/templates/preview.tsx
@@ -1,50 +1,54 @@
-"use client"
+'use client';
 
-import { LineItem, Region } from "@medusajs/medusa"
-import { Table, clx } from "@medusajs/ui"
+import { LineItem, Region } from '@medusajs/medusa';
+import { Table, clx } from '@medusajs/ui';
 
-import Item from "@modules/cart/components/item"
-import SkeletonLineItem from "@modules/skeletons/components/skeleton-line-item"
+import Item from '@modules/cart/components/item';
+import SkeletonLineItem from '@modules/skeletons/components/skeleton-line-item';
+
+type ExtendedLineItem = LineItem & {
+    currency_code?: string;
+};
 
 type ItemsTemplateProps = {
-  items?: Omit<LineItem, "beforeInsert">[]
-  region?: Region
-}
+    items?: Omit<ExtendedLineItem, 'beforeInsert'>[];
+    region?: Region;
+};
 
 const ItemsPreviewTemplate = ({ items, region }: ItemsTemplateProps) => {
-  const hasOverflow = items && items.length > 4
+    const hasOverflow = items && items.length > 4;
 
-  return (
-    <div
-      className={clx({
-        "pl-[1px] overflow-y-scroll overflow-x-hidden no-scrollbar max-h-[420px]":
-          hasOverflow,
-      })}
-    >
-      <Table>
-        <Table.Body>
-          {items && region
-            ? items
-                .sort((a, b) => {
-                  return a.created_at > b.created_at ? -1 : 1
-                })
-                .map((item) => {
-                  return (
-                    <Item
-                      key={item.id}
-                      item={item}
-                      region={region}
-                      type="preview"
-                    />
-                  )
-                })
-            : Array.from(Array(5).keys()).map((i) => {
-                return <SkeletonLineItem key={i} />
-              })}
-        </Table.Body>
-      </Table>
-    </div>
-  )
-}
+    return (
+        <div
+            className={clx({
+                'pl-[1px] overflow-y-scroll overflow-x-hidden no-scrollbar max-h-[420px]':
+                    hasOverflow,
+            })}
+        >
+            <Table>
+                <Table.Body>
+                    {items && region
+                        ? items
+                              .sort((a, b) => {
+                                  return a.created_at > b.created_at ? -1 : 1;
+                              })
+                              .map((item) => {
+                                  return (
+                                      <Item
+                                          key={item.id}
+                                          item={item}
+                                          region={region}
+                                          type="preview"
+                                      />
+                                  );
+                              })
+                        : Array.from(Array(5).keys()).map((i) => {
+                              return <SkeletonLineItem key={i} />;
+                          })}
+                </Table.Body>
+            </Table>
+        </div>
+    );
+};
 
-export default ItemsPreviewTemplate
+export default ItemsPreviewTemplate;

--- a/hamza-client/src/modules/common/components/line-item-price/index.tsx
+++ b/hamza-client/src/modules/common/components/line-item-price/index.tsx
@@ -5,10 +5,13 @@ import { clx } from '@medusajs/ui';
 import { getPercentageDiff } from '@lib/util/get-precentage-diff';
 import { CalculatedVariant } from 'types/medusa';
 import { formatCryptoPrice } from '@lib/util/get-product-price';
-import { useCustomerAuthStore } from '@store/customer-auth/customer-auth';
+
+type ExtendedLineItem = LineItem & {
+    currency_code?: string;
+};
 
 type LineItemPriceProps = {
-    item: Omit<LineItem, 'beforeInsert'>;
+    item: Omit<ExtendedLineItem, 'beforeInsert'>;
     region: Region;
     style?: 'default' | 'tight';
 };
@@ -21,8 +24,6 @@ const LineItemPrice = ({
     const originalPrice =
         (item.variant as CalculatedVariant).original_price * item.quantity;
     const hasReducedPrice = (item.total || 0) < originalPrice;
-
-    const { status, preferred_currency_code } = useCustomerAuthStore();
 
     return (
         <div className="flex flex-col gap-x-2 text-ui-fg-subtle items-end">
@@ -38,9 +39,9 @@ const LineItemPrice = ({
                             <span className="line-through text-ui-fg-muted">
                                 {formatCryptoPrice(
                                     originalPrice,
-                                    preferred_currency_code ?? 'usdt'
+                                    item.currency_code ?? 'usdt'
                                 )}{' '}
-                                {preferred_currency_code?.toUpperCase() ?? ''}
+                                {item.currency_code?.toUpperCase() ?? ''}
                             </span>
                         </p>
                         {style === 'default' && (
@@ -63,7 +64,7 @@ const LineItemPrice = ({
                     {!isNaN(originalPrice) &&
                         formatCryptoPrice(originalPrice, 'usdc') +
                             ' ' +
-                            (preferred_currency_code?.toUpperCase() ?? '')}
+                            (item.currency_code?.toUpperCase() ?? '')}
                 </span>
             </div>
         </div>

--- a/hamza-client/src/modules/common/components/line-item-unit-price/index.tsx
+++ b/hamza-client/src/modules/common/components/line-item-unit-price/index.tsx
@@ -7,8 +7,12 @@ import { CalculatedVariant } from 'types/medusa';
 import { formatCryptoPrice } from '@lib/util/get-product-price';
 import { useCustomerAuthStore } from '@store/customer-auth/customer-auth';
 
+type ExtendedLineItem = LineItem & {
+    currency_code?: string;
+};
+
 type LineItemUnitPriceProps = {
-    item: Omit<LineItem, 'beforeInsert'>;
+    item: Omit<ExtendedLineItem, 'beforeInsert'>;
     region: Region;
     style?: 'default' | 'tight';
 };
@@ -22,8 +26,6 @@ const LineItemUnitPrice = ({
     const hasReducedPrice = (originalPrice * item.quantity || 0) > item.total!;
     const reducedPrice = (item.total || 0) / item.quantity!;
 
-    const { status, preferred_currency_code } = useCustomerAuthStore();
-
     return (
         <div className="flex flex-col text-ui-fg-muted justify-center h-full">
             {hasReducedPrice && (
@@ -35,9 +37,9 @@ const LineItemUnitPrice = ({
                         <span className="line-through">
                             {formatCryptoPrice(
                                 originalPrice,
-                                preferred_currency_code ?? 'usdt'
+                                item.currency_code ?? 'usdt'
                             )}{' '}
-                            {preferred_currency_code?.toUpperCase() ?? ''}
+                            {item.currency_code?.toUpperCase() ?? ''}
                         </span>
                     </p>
                     {style === 'default' && (
@@ -59,9 +61,9 @@ const LineItemUnitPrice = ({
             >
                 {formatCryptoPrice(
                     reducedPrice || item.unit_price || 0,
-                    preferred_currency_code ?? 'usdt'
+                    item.currency_code ?? 'usdt'
                 )}{' '}
-                {preferred_currency_code?.toUpperCase() ?? ''}
+                {item.currency_code?.toUpperCase() ?? ''}
             </span>
         </div>
     );

--- a/hamza-client/src/modules/order/components/item/index.tsx
+++ b/hamza-client/src/modules/order/components/item/index.tsx
@@ -1,42 +1,54 @@
-import { LineItem, Region } from "@medusajs/medusa"
-import { Table, Text } from "@medusajs/ui"
+import { LineItem, Region } from '@medusajs/medusa';
+import { Table, Text } from '@medusajs/ui';
 
-import LineItemOptions from "@modules/common/components/line-item-options"
-import LineItemPrice from "@modules/common/components/line-item-price"
-import LineItemUnitPrice from "@modules/common/components/line-item-unit-price"
-import Thumbnail from "@modules/products/components/thumbnail"
+import LineItemOptions from '@modules/common/components/line-item-options';
+import LineItemPrice from '@modules/common/components/line-item-price';
+import LineItemUnitPrice from '@modules/common/components/line-item-unit-price';
+import Thumbnail from '@modules/products/components/thumbnail';
+
+type ExtendedLineItem = LineItem & {
+    currency_code?: string;
+};
 
 type ItemProps = {
-  item: Omit<LineItem, "beforeInsert">
-  region: Region
-}
+    item: Omit<ExtendedLineItem, 'beforeInsert'>;
+    region: Region;
+};
 
 const Item = ({ item, region }: ItemProps) => {
-  return (
-    <Table.Row className="w-full">
-      <Table.Cell className="!pl-0 p-4 w-24">
-        <div className="flex w-16">
-          <Thumbnail thumbnail={item.thumbnail} size="square" />
-        </div>
-      </Table.Cell>
+    return (
+        <Table.Row className="w-full">
+            <Table.Cell className="!pl-0 p-4 w-24">
+                <div className="flex w-16">
+                    <Thumbnail thumbnail={item.thumbnail} size="square" />
+                </div>
+            </Table.Cell>
 
-      <Table.Cell className="text-left">
-        <Text className="txt-medium-plus text-ui-fg-base">{item.title}</Text>
-        <LineItemOptions variant={item.variant} />
-      </Table.Cell>
+            <Table.Cell className="text-left">
+                <Text className="txt-medium-plus text-ui-fg-base">
+                    {item.title}
+                </Text>
+                <LineItemOptions variant={item.variant} />
+            </Table.Cell>
 
-      <Table.Cell className="!pr-0">
-        <span className="!pr-0 flex flex-col items-end h-full justify-center">
-          <span className="flex gap-x-1 ">
-            <Text className="text-ui-fg-muted">{item.quantity}x </Text>
-            <LineItemUnitPrice item={item} region={region} style="tight" />
-          </span>
+            <Table.Cell className="!pr-0">
+                <span className="!pr-0 flex flex-col items-end h-full justify-center">
+                    <span className="flex gap-x-1 ">
+                        <Text className="text-ui-fg-muted">
+                            {item.quantity}x{' '}
+                        </Text>
+                        <LineItemUnitPrice
+                            item={item}
+                            region={region}
+                            style="tight"
+                        />
+                    </span>
 
-          <LineItemPrice item={item} region={region} style="tight" />
-        </span>
-      </Table.Cell>
-    </Table.Row>
-  )
-}
+                    <LineItemPrice item={item} region={region} style="tight" />
+                </span>
+            </Table.Cell>
+        </Table.Row>
+    );
+};
 
-export default Item
+export default Item;

--- a/hamza-client/src/modules/products/components/product-actions/index.tsx
+++ b/hamza-client/src/modules/products/components/product-actions/index.tsx
@@ -146,6 +146,7 @@ export default function ProductActions({
             variantId: variant.id,
             quantity: 1,
             countryCode: countryCode,
+            currencyCode: 'eth', //variant.prices[0].currency_code,
         });
         setIsAdding(false);
     };

--- a/hamza-server/src/migrations/1894875825785-LineItem.ts
+++ b/hamza-server/src/migrations/1894875825785-LineItem.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MultiVendorPayment1893867137584 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "line_item" ADD COLUMN "currency_code" VARCHAR NOT NULL`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "line_item" ADD CONSTRAINT "FK_LineItem_Currency" FOREIGN KEY ("currency_code") REFERENCES "currency"("id")`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "payment" DROP COLUMN "currency_code"`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "line_item" DROP CONSTRAINT "FK_LineItem_Currency"`
+        );
+    }
+}

--- a/hamza-server/src/models/line-item.ts
+++ b/hamza-server/src/models/line-item.ts
@@ -1,0 +1,12 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import {
+    // alias the core entity to not cause a naming conflict
+    LineItem as MedusaLineItem,
+} from '@medusajs/medusa';
+import { Store } from './store';
+
+@Entity()
+export class LineItem extends MedusaLineItem {
+    @Column({ nullable: false, default: '' })
+    currency_code: string;
+}

--- a/hamza-server/src/services/cart.ts
+++ b/hamza-server/src/services/cart.ts
@@ -1,19 +1,21 @@
-import { CartService as MedusaCartService } from '@medusajs/medusa';
-import OrderRepository from '@medusajs/medusa/dist/repositories/order';
-import PaymentRepository from '@medusajs/medusa/dist/repositories/payment';
+import {
+    Cart,
+    CartService as MedusaCartService,
+    MoneyAmount,
+} from '@medusajs/medusa';
+import CustomerRepository from '@medusajs/medusa/dist/repositories/customer';
+import ProductVariantRepository from '@medusajs/medusa/dist/repositories/product-variant';
 import { LineItem } from '../models/line-item';
 import { Lifetime } from 'awilix';
 
 export default class CartService extends MedusaCartService {
     static LIFE_TIME = Lifetime.SINGLETON; // default, but just to show how to change it
 
-    protected orderRepository_: typeof OrderRepository;
-    protected paymentRepository_: typeof PaymentRepository;
+    //protected customerRepository_: typeof CustomerRepository;
+    //protected productVariantRepository_: typeof ProductVariantRepository;
 
     constructor(container) {
         super(container);
-        this.orderRepository_ = container.orderRepository;
-        this.paymentRepository_ = container.paymentRepository;
     }
 
     async addOrUpdateLineItems(
@@ -21,16 +23,58 @@ export default class CartService extends MedusaCartService {
         lineItems: LineItem | LineItem[],
         config: { validateSalesChannels: boolean }
     ): Promise<void> {
-        if (lineItems) {
-            if (Array.isArray(lineItems)) {
-                for (let n = 0; n < lineItems.length; n++) {
-                    lineItems[n].currency_code = 'eth';
-                }
-            } else {
-                lineItems.currency_code = 'eth';
-            }
+        const cart: Cart = await this.retrieve(cartId, {
+            relations: ['customer'],
+        });
+
+        //get preferred currency from customer
+        const preferredCurrency = cart?.customer?.preferred_currency_id;
+
+        //if not an array, make it one
+        if (!Array.isArray(lineItems)) {
+            lineItems = [lineItems];
         }
-        console.log('ADDING LINE ITEM', lineItems);
-        await super.addOrUpdateLineItems(cartId, lineItems, config);
+
+        //get all currencies
+        const promises: Promise<string>[] = [];
+        for (let n = 0; n < lineItems.length; n++) {
+            promises.push(
+                this.getCurrencyForLineItem(lineItems[n], preferredCurrency)
+            );
+        }
+
+        //assign currency results
+        const results: string[] = await Promise.all(promises);
+        for (let n = 0; n < lineItems.length; n++) {
+            lineItems[n].currency_code = results[n];
+        }
+
+        //call super
+        await super.addOrUpdateLineItems(
+            cartId,
+            lineItems.length === 1 ? lineItems[0] : lineItems,
+            config
+        );
+    }
+
+    private async getCurrencyForLineItem(
+        lineItem: LineItem,
+        preferredCurrency: string
+    ): Promise<string> {
+        const variant = await this.productVariantService_.retrieve(
+            lineItem.variant_id,
+            { relations: ['prices'] }
+        );
+
+        //find either the preferred currency price, or just the first
+        let price: MoneyAmount = null;
+        if (preferredCurrency) {
+            price = variant.prices.find(
+                (p) => p.currency_code == preferredCurrency
+            );
+        }
+
+        //if no preferred, return the first
+        return price?.currency_code ?? variant.prices[0].currency_code;
     }
 }

--- a/hamza-server/src/services/cart.ts
+++ b/hamza-server/src/services/cart.ts
@@ -1,6 +1,7 @@
-import { CartService as MedusaCartService, LineItem } from '@medusajs/medusa';
+import { CartService as MedusaCartService } from '@medusajs/medusa';
 import OrderRepository from '@medusajs/medusa/dist/repositories/order';
 import PaymentRepository from '@medusajs/medusa/dist/repositories/payment';
+import { LineItem } from '../models/line-item';
 import { Lifetime } from 'awilix';
 
 export default class CartService extends MedusaCartService {
@@ -20,7 +21,16 @@ export default class CartService extends MedusaCartService {
         lineItems: LineItem | LineItem[],
         config: { validateSalesChannels: boolean }
     ): Promise<void> {
+        if (lineItems) {
+            if (Array.isArray(lineItems)) {
+                for (let n = 0; n < lineItems.length; n++) {
+                    lineItems[n].currency_code = 'eth';
+                }
+            } else {
+                lineItems.currency_code = 'eth';
+            }
+        }
         console.log('ADDING LINE ITEM', lineItems);
-        super.addOrUpdateLineItems(cartId, lineItems, config);
+        await super.addOrUpdateLineItems(cartId, lineItems, config);
     }
 }

--- a/hamza-server/src/services/cart.ts
+++ b/hamza-server/src/services/cart.ts
@@ -1,0 +1,26 @@
+import { CartService as MedusaCartService, LineItem } from '@medusajs/medusa';
+import OrderRepository from '@medusajs/medusa/dist/repositories/order';
+import PaymentRepository from '@medusajs/medusa/dist/repositories/payment';
+import { Lifetime } from 'awilix';
+
+export default class CartService extends MedusaCartService {
+    static LIFE_TIME = Lifetime.SINGLETON; // default, but just to show how to change it
+
+    protected orderRepository_: typeof OrderRepository;
+    protected paymentRepository_: typeof PaymentRepository;
+
+    constructor(container) {
+        super(container);
+        this.orderRepository_ = container.orderRepository;
+        this.paymentRepository_ = container.paymentRepository;
+    }
+
+    async addOrUpdateLineItems(
+        cartId: string,
+        lineItems: LineItem | LineItem[],
+        config: { validateSalesChannels: boolean }
+    ): Promise<void> {
+        console.log('ADDING LINE ITEM', lineItems);
+        super.addOrUpdateLineItems(cartId, lineItems, config);
+    }
+}


### PR DESCRIPTION
This is concerned with mainly adding currency_code to LineItem, so that each line item, as it's added to the cart, has the currency already recorded. That way at checkout time, instead of calculating the correct currency to use, the currency will be just there in the line item. 
It will also be the basis for fixing price totals for cart. 

- LineItem extended on server side with currency_code
- LineItem extended on client side with currency_code
- LineItem given currency code when addded to cart 
- correct display of prices (with currency) in cart 
- updated CartCompletionStrategy to use line item currencies & prices