### PR TITLE
Fixed bug: Checkout button not cancelling (and Checkout cleanup) 

### DIFF
--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -207,6 +207,7 @@ const CryptoPaymentButton = ({
             };
         } catch (e) {
             console.error('error has occured during transaction', e);
+            setErrorMessage('Checkout was not completed.');
             setSubmitting(false);
         }
 
@@ -309,6 +310,7 @@ const CryptoPaymentButton = ({
                 );
             } else {
                 setSubmitting(false);
+                setErrorMessage('Checkout was not completed.');
             }
         } else {
             throw new Error('Checkout failed to complete.');
@@ -340,11 +342,14 @@ const CryptoPaymentButton = ({
                                 } catch (e) {
                                     console.error(e);
                                     setSubmitting(false);
+                                    setErrorMessage(
+                                        'Checkout was not completed.'
+                                    );
                                 }
                             },
                             onError: ({}) => {
                                 setSubmitting(false);
-                                throw new Error('Checkout is not completed');
+                                setErrorMessage('Checkout was not completed.');
                             },
                         });
                     },
@@ -355,6 +360,7 @@ const CryptoPaymentButton = ({
         } catch (e) {
             console.error(e);
             setSubmitting(false);
+            setErrorMessage('Checkout was not completed.');
         }
     };
 

--- a/hamza-client/src/modules/common/components/cart-totals/index.tsx
+++ b/hamza-client/src/modules/common/components/cart-totals/index.tsx
@@ -63,7 +63,7 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data }) => {
                             </Tooltip>
                         </span>
                         <span>
-                            {formatCryptoPrice(subtotals['eth'], 'eth')}
+                            {formatCryptoPrice(subtotals['eth'], 'eth')} ETH
                         </span>
                     </div>
                 )}
@@ -76,7 +76,7 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data }) => {
                             </Tooltip>
                         </span>
                         <span>
-                            {formatCryptoPrice(subtotals['usdt'], 'usdt')}
+                            {formatCryptoPrice(subtotals['usdt'], 'usdt')} USDT
                         </span>
                     </div>
                 )}
@@ -89,7 +89,7 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data }) => {
                             </Tooltip>
                         </span>
                         <span>
-                            {formatCryptoPrice(subtotals['usdc'], 'usdc')}
+                            {formatCryptoPrice(subtotals['usdc'], 'usdc')} USDC
                         </span>
                     </div>
                 )}

--- a/hamza-server/data/seed.json
+++ b/hamza-server/data/seed.json
@@ -17,7 +17,7 @@
             "name": "EU",
             "currency_code": "eth",
             "tax_rate": 0,
-            "payment_providers": ["manual", "crypto"],
+            "payment_providers": ["crypto"],
             "fulfillment_providers": ["manual"],
             "countries": ["gb", "de", "dk", "se", "fr", "es", "it"]
         },
@@ -26,7 +26,7 @@
             "name": "NA",
             "currency_code": "eth",
             "tax_rate": 0,
-            "payment_providers": ["manual", "crypto"],
+            "payment_providers": ["crypto"],
             "fulfillment_providers": ["manual"],
             "countries": ["us", "ca"]
         }


### PR DESCRIPTION
- cleaned up/ reorganized checkout on the client side (mainly)
- removed Manual payment method (we never use it)
- if checkout fails for any reason (error or rejected), button becomes enabled again 
- if checkout fails for any reason (error or rejected), message is displayed
- inventory updated only on successful checkout 
- added comments on payment-button page to clarify functions & code in general