### PR TITLE
Fixes to allow anonymous (not logged in) checkout

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -307,9 +307,13 @@ export async function getCustomer() {
         .retrieve(headers)
         .then(({ customer }) => customer)
         .catch((err) => {
-            cookies().set('_medusa_jwt', '', {
-                maxAge: -1,
-            });
+            try {
+                cookies().set('_medusa_jwt', '', {
+                    maxAge: -1,
+                });
+            } catch (e) {
+                console.error(e);
+            }
             return null;
         });
 }

--- a/hamza-client/src/modules/account/actions.ts
+++ b/hamza-client/src/modules/account/actions.ts
@@ -293,9 +293,13 @@ export async function updateCustomerBillingAddress(
 }
 
 export async function signOut() {
-    cookies().set('_medusa_jwt', '', {
-        maxAge: -1,
-    });
+    try {
+        cookies().set('_medusa_jwt', '', {
+            maxAge: -1,
+        });
+    } catch (e) {
+        console.error(e);
+    }
     const countryCode = headers().get('next-url')?.split('/')[1] || '';
     revalidateTag('auth');
     revalidateTag('customer');

--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { Cart, PaymentSession } from '@medusajs/medusa';
 import { Button } from '@medusajs/ui';
-import { placeOrder } from '@modules/checkout/actions';
 import React, { useState, useEffect, useRef } from 'react';
 import ErrorMessage from '../error-message';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
@@ -12,7 +11,6 @@ import { MasterSwitchClient } from 'web3/master-switch-client';
 import { ethers, BigNumberish } from 'ethers';
 import { useCompleteCart, useUpdateCart } from 'medusa-react';
 import { useRouter } from 'next/navigation';
-import { useQuery, useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { clearCart } from '@lib/data';
 import { getCurrencyPrecision } from 'currency.config';
@@ -40,6 +38,8 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({ cart }) => {
         cart.shipping_methods.length < 1
             ? true
             : false;
+
+    //TODO: what we need this fo?
     const paymentSession = cart.payment_session as PaymentSession;
 
     return <CryptoPaymentButton notReady={notReady} cart={cart} />;


### PR DESCRIPTION
The issue was that anonymous users going to checkout would encounter hard-crash errors on the way, preventing them from even getting to checkout. 

1. put cookie handling into a try/catch
2. requiring wallet connection on the 'review' step, rather than right at checkout; this is more efficient