### PR TITLE
Checkout email bug

### DIFF
--- a/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
@@ -201,11 +201,12 @@ const ShippingAddress = ({
                         autoComplete="email"
                         value={checkoutEmail}
                         onChange={handleChange}
+                        onFocus={() => setValidEmail(true)}
                         onBlur={() => validateEmail(checkoutEmail)}
                     />
                     {validEmail === false && (
                         <div style={{ color: 'red' }}>
-                            Please enter a valid email address
+                            The email you have entered is not valid
                         </div>
                     )}
                 </div>

--- a/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
@@ -33,6 +33,10 @@ const ShippingAddress = ({
         email: cart?.email || '',
         'shipping_address.phone': cart?.shipping_address?.phone || '',
     });
+
+    //keep track of user email
+    const [checkoutEmail, setCheckoutEmail] = useState('');
+
     // TODO (For G), take a look at what obj / type we are sending instead of passing any
     const countriesInRegion = useMemo(
         () => cart?.region.countries.map((c: any) => c.iso_2),
@@ -68,6 +72,11 @@ const ShippingAddress = ({
             email: cart?.email || '',
             'shipping_address.phone': cart?.shipping_address?.phone || '',
         });
+        setCheckoutEmail(
+            cart?.email && !cart?.email.endsWith('@evm.blockchain')
+                ? cart?.email
+                : ''
+        );
     }, [cart?.shipping_address, cart?.email]);
 
     const handleChange = (
@@ -75,10 +84,14 @@ const ShippingAddress = ({
             HTMLInputElement | HTMLInputElement | HTMLSelectElement
         >
     ) => {
+        const { name, value } = e.target;
         setFormData({
             ...formData,
-            [e.target.name]: e.target.value,
+            [name]: value,
         });
+        if (name === 'email') {
+            setCheckoutEmail(value);
+        }
     };
 
     return (
@@ -173,7 +186,7 @@ const ShippingAddress = ({
                     type="email"
                     title="Enter a valid email address."
                     autoComplete="email"
-                    value={formData.email}
+                    value={checkoutEmail}
                     onChange={handleChange}
                 />
                 <Input

--- a/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
@@ -34,8 +34,20 @@ const ShippingAddress = ({
         'shipping_address.phone': cart?.shipping_address?.phone || '',
     });
 
-    //keep track of user email
+    //Email states
     const [checkoutEmail, setCheckoutEmail] = useState('');
+    const [validEmail, setValidEmail] = useState(true);
+
+    //validate email address
+    const validateEmail = (email) => {
+        if (email === '') {
+            setValidEmail(true);
+            return;
+        } else {
+            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            setValidEmail(emailRegex.test(email));
+        }
+    };
 
     // TODO (For G), take a look at what obj / type we are sending instead of passing any
     const countriesInRegion = useMemo(
@@ -180,15 +192,23 @@ const ShippingAddress = ({
                 /> */}
             </div>
             <div className="grid grid-cols-2 gap-4 mb-4">
-                <Input
-                    label="Email"
-                    name="email"
-                    type="email"
-                    title="Enter a valid email address."
-                    autoComplete="email"
-                    value={checkoutEmail}
-                    onChange={handleChange}
-                />
+                <div>
+                    <Input
+                        label="Email"
+                        name="email"
+                        type="email"
+                        title="Enter a valid email address."
+                        autoComplete="email"
+                        value={checkoutEmail}
+                        onChange={handleChange}
+                        onBlur={() => validateEmail(checkoutEmail)}
+                    />
+                    {validEmail === false && (
+                        <div style={{ color: 'red' }}>
+                            Please enter a valid email address
+                        </div>
+                    )}
+                </div>
                 <Input
                     label="Phone"
                     name="shipping_address.phone"

--- a/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
@@ -175,7 +175,6 @@ const ShippingAddress = ({
                     autoComplete="email"
                     value={formData.email}
                     onChange={handleChange}
-                    required
                 />
                 <Input
                     label="Phone"


### PR DESCRIPTION
- Deleted the red asterisk removing email as a required field (field is now optional)
- If the user's profile email address ends with @evm.blockchain, the email input field is now empty
- If the user's profile email address does not end with @evm.blockchain, the email is displayed
- Added email input validation - if email is not correctly formatted it displays an error message underneath the input
- Error message deletes onFocus or if field is empty