### PR TITLE
Changed default anonymous customer first/last name

### DIFF
--- a/hamza-client/src/app/[countryCode]/(main)/account/@login/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/account/@login/page.tsx
@@ -8,5 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function Login() {
-    return <div>Use connect wallet to sign in.</div>;
+    return <div>Connect your wallet to sign in.</div>;
 }

--- a/hamza-client/src/app/[countryCode]/(main)/account/layout.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/account/layout.tsx
@@ -17,7 +17,7 @@ export default async function AccountPageLayout({
             ) : (
                 <>
                     <div>
-                        Use connect wallet to sign in and verify your account.
+                        Connect your wallet to sign in and verify your account.
                     </div>
                 </>
             )}

--- a/hamza-client/src/modules/account/components/login/index.tsx
+++ b/hamza-client/src/modules/account/components/login/index.tsx
@@ -17,7 +17,7 @@ const Login = ({ setCurrentView }: Props) => {
         <div className="max-w-sm w-full flex flex-col items-center">
             <h1 className="text-large-semi uppercase mb-6">Welcome back</h1>
             <p className="text-center text-base-regular text-ui-fg-base mb-8">
-                Use connect wallet to sign in.
+                Connect your wallet to sign in.
             </p>
         </div>
     );

--- a/hamza-client/src/modules/account/components/register/index.tsx
+++ b/hamza-client/src/modules/account/components/register/index.tsx
@@ -16,78 +16,7 @@ type Props = {
 const Register = ({ setCurrentView }: Props) => {
     const [message, formAction] = useFormState(signUp, null);
 
-    return (
-        // <div className="max-w-sm flex flex-col items-center">
-        //   <h1 className="text-large-semi uppercase mb-6">
-        //     Become a Medusa Store Member
-        //   </h1>
-        //   <p className="text-center text-base-regular text-ui-fg-base mb-4">
-        //     Create your Medusa Store Member profile, and get access to an enhanced
-        //     shopping experience.
-        //   </p>
-        //   <form className="w-full flex flex-col" action={formAction}>
-        //     <div className="flex flex-col w-full gap-y-2">
-        //       <Input
-        //         label="First name"
-        //         name="first_name"
-        //         required
-        //         autoComplete="given-name"
-        //       />
-        //       <Input
-        //         label="Last name"
-        //         name="last_name"
-        //         required
-        //         autoComplete="family-name"
-        //       />
-        //       <Input
-        //         label="Email"
-        //         name="email"
-        //         required
-        //         type="email"
-        //         autoComplete="email"
-        //       />
-        //       <Input label="Phone" name="phone" type="tel" autoComplete="tel" />
-        //       <Input
-        //         label="Password"
-        //         name="password"
-        //         required
-        //         type="password"
-        //         autoComplete="new-password"
-        //       />
-        //     </div>
-        //     <ErrorMessage error={message} />
-        //     <span className="text-center text-ui-fg-base text-small-regular mt-6">
-        //       By creating an account, you agree to Medusa Store&apos;s{" "}
-        //       <LocalizedClientLink
-        //         href="/content/privacy-policy"
-        //         className="underline"
-        //       >
-        //         Privacy Policy
-        //       </LocalizedClientLink>{" "}
-        //       and{" "}
-        //       <LocalizedClientLink
-        //         href="/content/terms-of-use"
-        //         className="underline"
-        //       >
-        //         Terms of Use
-        //       </LocalizedClientLink>
-        //       .
-        //     </span>
-        //     <SubmitButton className="w-full mt-6">Join</SubmitButton>
-        //   </form>
-        //   <span className="text-center text-ui-fg-base text-small-regular mt-6">
-        //     Already a member?{" "}
-        //     <button
-        //       onClick={() => setCurrentView(LOGIN_VIEW.SIGN_IN)}
-        //       className="underline"
-        //     >
-        //       Sign in
-        //     </button>
-        //     .
-        //   </span>
-        // </div>
-        <div>Connect your wallet to sign in</div>
-    );
+    return <div>Connect your wallet to sign in</div>;
 };
 
 export default Register;

--- a/hamza-client/src/modules/account/components/register/index.tsx
+++ b/hamza-client/src/modules/account/components/register/index.tsx
@@ -86,7 +86,7 @@ const Register = ({ setCurrentView }: Props) => {
         //     .
         //   </span>
         // </div>
-        <div>Use connect wallet to sign in</div>
+        <div>Connect your wallet to sign in</div>
     );
 };
 

--- a/hamza-client/src/modules/cart/components/sign-in-prompt/index.tsx
+++ b/hamza-client/src/modules/cart/components/sign-in-prompt/index.tsx
@@ -20,7 +20,7 @@ const SignInPrompt = () => {
         //         </LocalizedClientLink>
         //     </div>
         // </div>
-        <div>Use Connect wallet to sign in</div>
+        <div>Connect your wallet to sign in</div>
     );
 };
 

--- a/hamza-server/src/api/custom/verify/route.ts
+++ b/hamza-server/src/api/custom/verify/route.ts
@@ -36,11 +36,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         //create customer input data
         const customerInputData = {
             email: `${checkCustomerWithWalletAddress && checkCustomerWithWalletAddress.customer ? checkCustomerWithWalletAddress.customer.email : `${wallet_address}@evm.blockchain`}`,
-            first_name:
-                wallet_address.length >= 10
-                    ? wallet_address.substring(0, 10)
-                    : wallet_address,
-            last_name: '',
+            first_name: 'Anonymous',
+            last_name: 'Gigachad',
             password: 'password', //TODO: (JK) store the default password someplace
             wallet_address: wallet_address,
         };


### PR DESCRIPTION
When user is created anonymously, we used to give them first/last names that were substrings of their wallet address. 
Now they have a default first/last name.