### PR TITLE
Client build fixes: Breaking product page

### DIFF
--- a/hamza-client/src/lib/util/prices.ts
+++ b/hamza-client/src/lib/util/prices.ts
@@ -228,7 +228,7 @@ export const formatAmount = ({
         includeTaxes,
     });
 
-    return `${amount.toFixed(2)} ${currency_code.toUpperCase()}`
+    return `${parseInt(amount.toString()).toFixed(2)} ${currency_code.toUpperCase()}`
     return convertToLocale({
         amount: taxAwareAmount,
         currency_code,


### PR DESCRIPTION
This one small issue was breaking product page; 'amount' sometimes might not be number, so converting it to one