### PR TITLE
Bug: cart id undefined in finalizeCheckout

### DIFF
--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -269,7 +269,7 @@ const CryptoPaymentButton = ({
                     `${MEDUSA_SERVER_URL}/custom/checkout`,
                     {
                         cartProducts: JSON.stringify(cartRef.current),
-                        cart_id: data.cart_id,
+                        cart_id: cartId,
                         transaction_id: output.transaction_id,
                         payer_address: output.payer_address,
                         escrow_contract_address: output.escrow_contract_address,


### PR DESCRIPTION
The wrong variable for cart id was being passed to finalizeCheckout from the front end. Now the right one is.