### PR TITLE
homepage price fixes

### DIFF
--- a/hamza-client/src/modules/home/components/product-layout/index.tsx
+++ b/hamza-client/src/modules/home/components/product-layout/index.tsx
@@ -63,7 +63,7 @@ const ProductCardGroup = ({ vendorName, category }: Props) => {
                         );
                         const avgRating = totalRating / reviewCounter;
                         const productPricing = formatCryptoPrice(
-                            variantPrices[0].amount,
+                            variantPrices.find((p: any) => p.currency_code === preferred_currency_code).amount,
                             preferred_currency_code as string
                         );
                         variantID = product.variants[0].id;

--- a/hamza-client/src/modules/products/components/product-card-group/index.tsx
+++ b/hamza-client/src/modules/products/components/product-card-group/index.tsx
@@ -133,7 +133,7 @@ const ProductCardGroup = ({
                             .flat();
 
                         const productPricing = formatCryptoPrice(
-                            variantPrices[0].amount,
+                            variantPrices.find((p: any) => p.currency_code === preferred_currency_code).amount,
                             preferred_currency_code as string
                         );
                         const reviewCounter = product.reviews.length;


### PR DESCRIPTION
Passing to product card variant.prices[0], but it should have been choosing that price that matches the preferred currency. Now it's better. 