### PR TITLE
force us country code when add to cart

### DIFF
--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -82,13 +82,17 @@ export async function addToCart({
     countryCode: string;
     currencyCode: string;
 }) {
+    if (process.env.NEXT_PUBLIC_FORCE_US_COUNTRY)
+        countryCode = 'us';
     const cart = await getOrSetCart(countryCode).then((cart) => cart);
 
     if (!cart) {
+        console.log('Missing cart ID ', countryCode);
         return 'Missing cart ID';
     }
 
     if (!variantId) {
+        console.log('Missing var ID');
         return 'Missing product variant ID';
     }
 
@@ -101,6 +105,7 @@ export async function addToCart({
         });
         revalidateTag('cart');
     } catch (e) {
+        console.error(e);
         return 'Error adding item to cart';
     }
 }
@@ -166,9 +171,9 @@ export async function enrichLineItems(
     regionId: string
 ): Promise<
     | Omit<
-          ExtendedLineItem,
-          'beforeInsert' | 'beforeUpdate' | 'afterUpdateOrLoad'
-      >[]
+        ExtendedLineItem,
+        'beforeInsert' | 'beforeUpdate' | 'afterUpdateOrLoad'
+    >[]
     | undefined
 > {
     // Prepare query parameters

--- a/hamza-client/src/modules/products/components/mobile-actions/index.tsx
+++ b/hamza-client/src/modules/products/components/mobile-actions/index.tsx
@@ -124,8 +124,8 @@ const MobileActions: React.FC<MobileActionsProps> = ({
                                 {!variant
                                     ? 'Select variant'
                                     : !inStock
-                                      ? 'Out of stock'
-                                      : 'Add to cart'}
+                                        ? 'Out of stock'
+                                        : 'Add to Cart'}
                             </Button>
                         </div>
                     </div>
@@ -180,8 +180,8 @@ const MobileActions: React.FC<MobileActionsProps> = ({
                                                                     }
                                                                     current={
                                                                         options[
-                                                                            option
-                                                                                .id
+                                                                        option
+                                                                            .id
                                                                         ]
                                                                     }
                                                                     updateOption={

--- a/hamza-client/src/modules/products/components/product-actions/index.tsx
+++ b/hamza-client/src/modules/products/components/product-actions/index.tsx
@@ -181,19 +181,19 @@ export default function ProductActions({
         // console.log('toggle wishlist-dropdown item', product);
         wishlist.products.find((a) => a.id == product.id)
             ? removeWishlistItemMutation.mutate({
-                  id: product.id!,
-                  description: product.description!,
-                  handle: product.handle!,
-                  thumbnail: product.thumbnail!,
-                  title: product.title!,
-              })
+                id: product.id!,
+                description: product.description!,
+                handle: product.handle!,
+                thumbnail: product.thumbnail!,
+                title: product.title!,
+            })
             : addWishlistItemMutation.mutate({
-                  id: product.id!,
-                  description: product.description!,
-                  handle: product.handle!,
-                  thumbnail: product.thumbnail!,
-                  title: product.title!,
-              });
+                id: product.id!,
+                description: product.description!,
+                handle: product.handle!,
+                thumbnail: product.thumbnail!,
+                title: product.title!,
+            });
     };
 
     const whitelistedProductHandler = async () => {
@@ -206,7 +206,7 @@ export default function ProductActions({
         if (data.status == true) {
             const whitelistedProduct =
                 whitelist_config.is_whitelisted &&
-                whitelist_config.whitelisted_stores.includes(data.data)
+                    whitelist_config.whitelisted_stores.includes(data.data)
                     ? true
                     : false;
 
@@ -275,10 +275,10 @@ export default function ProductActions({
                     {!variant
                         ? 'Select variant'
                         : !inStock && isWhitelisted
-                          ? 'Add to cart'
-                          : inStock
                             ? 'Add to Cart'
-                            : 'Out of Stock'}
+                            : inStock
+                                ? 'Add to Cart'
+                                : 'Out of Stock'}
                 </Button>
                 {!inStock && isWhitelisted && (
                     <span className="text-xs">


### PR DESCRIPTION
- fixed bug: if for some reason your countryCode is not valid (which is a code smell), but if FORCE_US_COUNTRY is true, add to cart from prod detail page will still work. 
- make 'Add to Cart' text consistent (vs. 'Add to cart')