### PR TITLE
fixed bug in MassMarket events reading (event stream resets, solved u…

### DIFF
--- a/massmarket-rest-api/hamza/src/controllers/checkout.ts
+++ b/massmarket-rest-api/hamza/src/controllers/checkout.ts
@@ -109,31 +109,44 @@ export const checkoutController = {
                         console.log('COMMITTING CART');
                         await rc.commitCart(cartId, input.paymentCurrency);
 
+                        //try a number of times to retrieve the checkout event
                         const numRetries = 3;
                         let retry = 0;
                         while (retry < numRetries) {
                             console.log('trying to get checkout event...');
                             const event =
-                                await rc.getCartFinalizedEvent(cartId);
+                                await await rc.getCartFinalizedEvent(cartId);
+
+                            //if event is gotten, then return output from it
                             if (event) {
+                                //order id or order hash
                                 checkoutOutput.orderHash = bytesToHex(
                                     event.orderHash
                                 );
+
+                                //ttl & amount
                                 checkoutOutput.ttl = parseInt(event.ttl);
                                 checkoutOutput.amount = bytesToHex(
                                     event.totalInCrypto
                                 );
+
+                                //currency & payee address
                                 checkoutOutput.currency = input.paymentCurrency
                                     ? bytesToHex(event.currencyAddr)
                                     : '0x0000000000000000000000000000000000000000';
                                 checkoutOutput.payeeAddress = bytesToHex(
                                     event.payeeAddr
                                 );
+
+                                //this is passed into multiPay
+                                checkoutOutput.isPaymentEndpoint =
+                                    event.isPaymentEndpoint;
+
+                                //this is like a checksum
                                 checkoutOutput.paymentId = bytesToHex(
                                     event.paymentId
                                 );
-                                checkoutOutput.isPaymentEndpoint =
-                                    event.isPaymentEndpoint;
+
                                 checkoutOutput.success = true;
                                 break;
                             } else {
@@ -146,8 +159,6 @@ export const checkoutController = {
 
                         output = checkoutOutput;
                     }
-
-                    await rc.disconnect();
                 }
 
                 console.log('returning output', output);


### PR DESCRIPTION
…sing tee())

Massmarket checkout had a specific bug where, after you run checkout once and get the itemsFinalized event, the next time you tried to read any events, they'd be empty (no events). So the second (and subsequent) checkouts would be unable to retrieve the event (and would fail). 

Now splitting the eventstream into two using tee() before using it. The second one of the two is then saved for the next reading session, at which time it's split, etc... Every time it's used it gets split into two first, and the read one gets tossed while the unread one is saved for next time. 