### PR TITLE
Checkout: missing cart Id on Delivery Step

### DIFF
--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -53,7 +53,7 @@ export default async function Checkout(params: any) {
     return (
         <div className="grid grid-cols-1 small:grid-cols-[1fr_416px] content-container gap-x-40 py-12 bg-black">
             <Wrapper cart={cart}>
-                <CheckoutForm />
+                <CheckoutForm cartId={cartId} />
             </Wrapper>
             <CheckoutSummary cartId={cartId} />
         </div>

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -12,7 +12,12 @@ export const metadata: Metadata = {
     title: 'Checkout',
 };
 
+const sleep = (seconds: number) => {
+    return new Promise((resolve, reject) => { setTimeout(() => resolve(true), seconds * 1000) });
+}
+
 const fetchCart = async () => {
+    await sleep(3);
     const cart = await retrieveCart();
 
     if (cart?.items.length) {

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -20,6 +20,7 @@ const sleep = (seconds: number) => {
 
 const fetchCart = async (cartId: string) => {
     const cart = await retrieveCart(cartId);
+    console.log(cart);
 
     if (cart?.items.length) {
         const enrichedItems = await enrichLineItems(
@@ -32,9 +33,10 @@ const fetchCart = async (cartId: string) => {
     return cart;
 };
 
-export default async function Checkout(cartId: string) {
-    //if (!cartId) cartId = cookies().get('_medusa_cart_id')?.value;
-    console.log('got cartId', cartId);
+export default async function Checkout(params: any) {
+    let cartId = cookies().get('_medusa_cart_id')?.value;
+    if (!cartId && params?.searchParams?.cart)
+        cartId = params.searchParams.cart;
 
     if (!cartId) {
         console.log('cart id not found');

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { cookies } from 'next/headers';
-import { notFound, useSearchParams } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { LineItem } from '@medusajs/medusa';
 
 import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
@@ -20,7 +20,6 @@ const sleep = (seconds: number) => {
 
 const fetchCart = async (cartId: string) => {
     const cart = await retrieveCart(cartId);
-    console.log(cart);
 
     if (cart?.items.length) {
         const enrichedItems = await enrichLineItems(

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -34,14 +34,17 @@ const fetchCart = async (cartId: string) => {
 
 export default async function Checkout(cartId: string) {
     //if (!cartId) cartId = cookies().get('_medusa_cart_id')?.value;
+    console.log('got cartId', cartId);
 
     if (!cartId) {
+        console.log('cart id not found');
         return notFound();
     }
 
     const cart = await fetchCart(cartId);
 
     if (!cart) {
+        console.log('cart data not found');
         return notFound();
     }
 

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { cookies } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, useSearchParams } from 'next/navigation';
 import { LineItem } from '@medusajs/medusa';
 
 import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
@@ -13,12 +13,14 @@ export const metadata: Metadata = {
 };
 
 const sleep = (seconds: number) => {
-    return new Promise((resolve, reject) => { setTimeout(() => resolve(true), seconds * 1000) });
-}
+    return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(true), seconds * 1000);
+    });
+};
 
 const fetchCart = async () => {
-    await sleep(3);
-    const cart = await retrieveCart();
+    const searchParams = useSearchParams();
+    const cart = await retrieveCart(searchParams.get('cart'));
 
     if (cart?.items.length) {
         const enrichedItems = await enrichLineItems(
@@ -32,7 +34,7 @@ const fetchCart = async () => {
 };
 
 export default async function Checkout() {
-    const cartId = cookies().get('_medusa_cart_id')?.value;
+    let cartId = cookies().get('_medusa_cart_id')?.value;
 
     if (!cartId) {
         return notFound();

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -18,9 +18,8 @@ const sleep = (seconds: number) => {
     });
 };
 
-const fetchCart = async () => {
-    const searchParams = useSearchParams();
-    const cart = await retrieveCart(searchParams.get('cart'));
+const fetchCart = async (cartId: string) => {
+    const cart = await retrieveCart(cartId);
 
     if (cart?.items.length) {
         const enrichedItems = await enrichLineItems(
@@ -40,7 +39,7 @@ export default async function Checkout(cartId: string) {
         return notFound();
     }
 
-    const cart = await fetchCart();
+    const cart = await fetchCart(cartId);
 
     if (!cart) {
         return notFound();

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -33,8 +33,8 @@ const fetchCart = async () => {
     return cart;
 };
 
-export default async function Checkout() {
-    let cartId = cookies().get('_medusa_cart_id')?.value;
+export default async function Checkout(cartId: string) {
+    //if (!cartId) cartId = cookies().get('_medusa_cart_id')?.value;
 
     if (!cartId) {
         return notFound();

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -55,7 +55,7 @@ export default async function Checkout(params: any) {
             <Wrapper cart={cart}>
                 <CheckoutForm />
             </Wrapper>
-            <CheckoutSummary />
+            <CheckoutSummary cartId={cartId} />
         </div>
     );
 }

--- a/hamza-client/src/app/[countryCode]/(checkout)/not-found.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/not-found.tsx
@@ -13,7 +13,7 @@ export default async function NotFound() {
       <p className="text-small-regular text-ui-fg-base">
         The page you tried to access does not exist.
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <InteractiveLink href="/">Go to homepage</InteractiveLink>
     </div>
   )
 }

--- a/hamza-client/src/app/[countryCode]/(main)/cart/not-found.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/cart/not-found.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
         The cart you tried to access does not exist. Clear your cookies and try
         again.
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <InteractiveLink href="/">Go to homepage</InteractiveLink>
     </div>
   )
 }

--- a/hamza-client/src/app/[countryCode]/(main)/cart/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/cart/page.tsx
@@ -1,38 +1,44 @@
-import { LineItem } from "@medusajs/medusa"
-import { Metadata } from "next"
+import { LineItem } from '@medusajs/medusa';
+import { Metadata } from 'next';
 
-import CartTemplate from "@modules/cart/templates"
+import CartTemplate from '@modules/cart/templates';
 
-import { enrichLineItems, retrieveCart } from "@modules/cart/actions"
-import { getCheckoutStep } from "@lib/util/get-checkout-step"
-import { CartWithCheckoutStep } from "types/global"
-import { getCustomer } from "@lib/data"
+import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
+import { getCheckoutStep } from '@lib/util/get-checkout-step';
+import { CartWithCheckoutStep } from 'types/global';
+import { getCustomer } from '@lib/data';
 
 export const metadata: Metadata = {
-  title: "Cart",
-  description: "View your cart",
-}
+    title: 'Cart',
+    description: 'View your cart',
+};
 
 const fetchCart = async () => {
-  const cart = await retrieveCart().then((cart) => cart as CartWithCheckoutStep)
+    console.log('calling retrieveCart from cart/page');
+    const cart = await retrieveCart().then(
+        (cart) => cart as CartWithCheckoutStep
+    );
 
-  if (!cart) {
-    return null
-  }
+    if (!cart) {
+        return null;
+    }
 
-  if (cart?.items.length) {
-    const enrichedItems = await enrichLineItems(cart?.items, cart?.region_id)
-    cart.items = enrichedItems as LineItem[]
-  }
+    if (cart?.items.length) {
+        const enrichedItems = await enrichLineItems(
+            cart?.items,
+            cart?.region_id
+        );
+        cart.items = enrichedItems as LineItem[];
+    }
 
-  cart.checkout_step = cart && getCheckoutStep(cart)
+    cart.checkout_step = cart && getCheckoutStep(cart);
 
-  return cart
-}
+    return cart;
+};
 
 export default async function Cart() {
-  const cart = await fetchCart()
-  const customer = await getCustomer()
+    const cart = await fetchCart();
+    const customer = await getCustomer();
 
-  return <CartTemplate cart={cart} customer={customer} />
+    return <CartTemplate cart={cart} customer={customer} />;
 }

--- a/hamza-client/src/app/[countryCode]/(main)/not-found.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
       <p className="text-small-regular text-ui-fg-base">
         The page you tried to access does not exist.
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <InteractiveLink href="/">Go to homepage</InteractiveLink>
     </div>
   )
 }

--- a/hamza-client/src/app/not-found.tsx
+++ b/hamza-client/src/app/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
       <p className="text-small-regular text-ui-fg-base">
         The page you tried to access does not exist.
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <InteractiveLink href="/">Go to homepage</InteractiveLink>
     </div>
   )
 }

--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -58,15 +58,17 @@ export async function getOrSetCart(countryCode: string) {
 export async function retrieveCart(
     cartId: string | null | undefined = undefined
 ) {
-    console.log('cart id: ', cartId);
     if (!cartId?.length) cartId = cookies().get('_medusa_cart_id')?.value;
+    console.log('cart id in retrieveCart: ', cartId);
 
     if (!cartId) {
+        console.log('retrieveCart returning null');
         return null;
     }
 
     try {
         const cart = await getCart(cartId).then((cart) => cart);
+        console.log('retrieveCart returning cart');
         return cart;
     } catch (e) {
         console.error(e);

--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -55,8 +55,10 @@ export async function getOrSetCart(countryCode: string) {
     return cart;
 }
 
-export async function retrieveCart() {
-    const cartId = cookies().get('_medusa_cart_id')?.value;
+export async function retrieveCart(
+    cartId: string | null | undefined = undefined
+) {
+    if (!cartId?.length) cartId = cookies().get('_medusa_cart_id')?.value;
 
     if (!cartId) {
         return null;
@@ -82,8 +84,7 @@ export async function addToCart({
     countryCode: string;
     currencyCode: string;
 }) {
-    if (process.env.NEXT_PUBLIC_FORCE_US_COUNTRY)
-        countryCode = 'us';
+    if (process.env.NEXT_PUBLIC_FORCE_US_COUNTRY) countryCode = 'us';
     const cart = await getOrSetCart(countryCode).then((cart) => cart);
 
     if (!cart) {
@@ -171,9 +172,9 @@ export async function enrichLineItems(
     regionId: string
 ): Promise<
     | Omit<
-        ExtendedLineItem,
-        'beforeInsert' | 'beforeUpdate' | 'afterUpdateOrLoad'
-    >[]
+          ExtendedLineItem,
+          'beforeInsert' | 'beforeUpdate' | 'afterUpdateOrLoad'
+      >[]
     | undefined
 > {
     // Prepare query parameters

--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -58,6 +58,7 @@ export async function getOrSetCart(countryCode: string) {
 export async function retrieveCart(
     cartId: string | null | undefined = undefined
 ) {
+    console.log('cart id: ', cartId);
     if (!cartId?.length) cartId = cookies().get('_medusa_cart_id')?.value;
 
     if (!cartId) {
@@ -68,7 +69,7 @@ export async function retrieveCart(
         const cart = await getCart(cartId).then((cart) => cart);
         return cart;
     } catch (e) {
-        console.log(e);
+        console.error(e);
         return null;
     }
 }

--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -59,7 +59,6 @@ export async function retrieveCart(
     cartId: string | null | undefined = undefined
 ) {
     if (!cartId?.length) cartId = cookies().get('_medusa_cart_id')?.value;
-    console.log('cart id in retrieveCart: ', cartId);
 
     if (!cartId) {
         console.log('retrieveCart returning null');
@@ -68,7 +67,6 @@ export async function retrieveCart(
 
     try {
         const cart = await getCart(cartId).then((cart) => cart);
-        console.log('retrieveCart returning cart');
         return cart;
     } catch (e) {
         console.error(e);

--- a/hamza-client/src/modules/checkout/actions.ts
+++ b/hamza-client/src/modules/checkout/actions.ts
@@ -144,7 +144,7 @@ export async function setAddresses(currentState: unknown, formData: FormData) {
     }
 
     redirect(
-        `/${process.env.NEXT_PUBLIC_FORCE_US_COUNTRY ? 'us' : formData.get('shipping_address.country_code')}/checkout?step=delivery`
+        `/${process.env.NEXT_PUBLIC_FORCE_US_COUNTRY ? 'us' : formData.get('shipping_address.country_code')}/checkout?step=delivery&cart=${cartId}`
     );
 }
 

--- a/hamza-client/src/modules/checkout/components/shipping/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping/index.tsx
@@ -32,6 +32,7 @@ const Shipping: React.FC<ShippingProps> = ({
     const pathname = usePathname();
 
     const isOpen = searchParams.get('step') === 'delivery';
+    const cartId = isOpen ? searchParams.get('cart') : cart.id;
 
     const handleEdit = () => {
         router.push(pathname + `?step=delivery&cart=${cart.id}`, {

--- a/hamza-client/src/modules/checkout/components/shipping/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping/index.tsx
@@ -34,7 +34,9 @@ const Shipping: React.FC<ShippingProps> = ({
     const isOpen = searchParams.get('step') === 'delivery';
 
     const handleEdit = () => {
-        router.push(pathname + '?step=delivery', { scroll: false });
+        router.push(pathname + `?step=delivery&cart=${cart.id}`, {
+            scroll: false,
+        });
     };
 
     const handleSubmit = () => {

--- a/hamza-client/src/modules/checkout/templates/checkout-form/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-form/index.tsx
@@ -11,8 +11,8 @@ import { cookies } from 'next/headers';
 import { CartWithCheckoutStep } from 'types/global';
 import { getCheckoutStep } from '@lib/util/get-checkout-step';
 
-export default async function CheckoutForm() {
-    const cartId = cookies().get('_medusa_cart_id')?.value;
+export default async function CheckoutForm(params: any) {
+    const cartId = params.cartId;
 
     if (!cartId) {
         return null;

--- a/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -8,6 +8,7 @@ import { retrieveCart } from '@modules/cart/actions';
 
 const CheckoutSummary = async (params: any) => {
     console.log('calling retrieveCart from checkout-summary');
+    console.log(params);
     //let cartId = cookies().get('_medusa_cart_id')?.value;
     let cartId = null;
     if (!cartId && params?.searchParams?.cart)

--- a/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -7,14 +7,11 @@ import Divider from '@modules/common/components/divider';
 import { retrieveCart } from '@modules/cart/actions';
 
 const CheckoutSummary = async (params: any) => {
-    console.log('calling retrieveCart from checkout-summary');
-    console.log(params);
-    //let cartId = cookies().get('_medusa_cart_id')?.value;
-    let cartId = null;
-    if (!cartId && params.cartId) cartId = params.cartId;
+    const cartId = params.cartId;
     const cart = await retrieveCart(cartId).then((cart) => cart);
 
     if (!cart) {
+        console.log('cart not found');
         return null;
     }
 

--- a/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -11,7 +11,7 @@ const CheckoutSummary = async (params: any) => {
     console.log(params);
     //let cartId = cookies().get('_medusa_cart_id')?.value;
     let cartId = null;
-    if (!cartId && params.cartId) cartId = params.searchParams.cart;
+    if (!cartId && params.cartId) cartId = params.cartId;
     const cart = await retrieveCart(cartId).then((cart) => cart);
 
     if (!cart) {

--- a/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -6,9 +6,13 @@ import CartTotals from '@modules/common/components/cart-totals';
 import Divider from '@modules/common/components/divider';
 import { retrieveCart } from '@modules/cart/actions';
 
-const CheckoutSummary = async () => {
+const CheckoutSummary = async (params: any) => {
     console.log('calling retrieveCart from checkout-summary');
-    const cart = await retrieveCart().then((cart) => cart);
+    //let cartId = cookies().get('_medusa_cart_id')?.value;
+    let cartId = null;
+    if (!cartId && params?.searchParams?.cart)
+        cartId = params.searchParams.cart;
+    const cart = await retrieveCart(cartId).then((cart) => cart);
 
     if (!cart) {
         return null;

--- a/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -11,8 +11,7 @@ const CheckoutSummary = async (params: any) => {
     console.log(params);
     //let cartId = cookies().get('_medusa_cart_id')?.value;
     let cartId = null;
-    if (!cartId && params?.searchParams?.cart)
-        cartId = params.searchParams.cart;
+    if (!cartId && params.cartId) cartId = params.searchParams.cart;
     const cart = await retrieveCart(cartId).then((cart) => cart);
 
     if (!cart) {

--- a/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -7,6 +7,7 @@ import Divider from '@modules/common/components/divider';
 import { retrieveCart } from '@modules/cart/actions';
 
 const CheckoutSummary = async () => {
+    console.log('calling retrieveCart from checkout-summary');
     const cart = await retrieveCart().then((cart) => cart);
 
     if (!cart) {

--- a/hamza-client/src/modules/layout/components/cart-button/index.tsx
+++ b/hamza-client/src/modules/layout/components/cart-button/index.tsx
@@ -5,6 +5,7 @@ import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
 import CartDropdown from '../cart-dropdown';
 
 const fetchCart = async () => {
+    console.log('calling retrieveCart from checkout-button');
     const cart = await retrieveCart();
 
     if (cart?.items.length) {


### PR DESCRIPTION
Missing cart id (unretrievable from cookies  in production build for some reason) causing blank page in checkout. 

Fixed by passing the cart Id around, instead of retrieving from cookies (in a few select places)