### PR TITLE
Hack for mobile checkout

### DIFF
--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -204,6 +204,13 @@ const CryptoPaymentButton = ({
                     success:
                         transaction_id && transaction_id.length ? true : false,
                 };
+            } else {
+                return {
+                    transaction_id: '0x21',
+                    payer_address: '0x32',
+                    escrow_contract_address: '0x42',
+                    success: true,
+                };
             }
         } catch (e) {
             console.error('error has occured during transaction', e);


### PR DESCRIPTION
If window.ethereum is not present, then checkout will just go through 
This is a good fix for non-wallet-having users who are just curious, as well. 
For actual mobile checkout, another fix will be needed; but this is a good start. 