### PR TITLE
commented out the 'onRehydrateStorage' handler for wishlist

### DIFF
--- a/hamza-client/src/store/wishlist/wishlist-store.tsx
+++ b/hamza-client/src/store/wishlist/wishlist-store.tsx
@@ -99,7 +99,8 @@ const useWishlistStore = create<WishlistType>()(
             storage: createJSONStorage(() => localStorage),
             // Optional: You can trigger loadWishlist after the store has been rehydrated from localStorage
             onRehydrateStorage: () => (state, error) => {
-                // console.log('Rehydration process triggered');
+                console.log('Rehydration process triggered');
+                /*
                 if (error) {
                     console.error('Rehydration error:', error);
                     return;
@@ -144,6 +145,7 @@ const useWishlistStore = create<WishlistType>()(
                 } else {
                     console.log('No customer data found in local storage.');
                 }
+                */
             },
         }
     )


### PR DESCRIPTION
It looks like this is what's happening: 

- normally, the wishlist creation and management is happening just fine 
- when the 'onRehydrateStorage' handler in wishlist-store.tsx (just search for 'onRehydrateStorage') is getting called, it's getting the wrong customer_id. Then it's trying to create a wishlist for that customer, which maybe doesn't exist. 
- the wrong customer id is coming from localStorage, '__hamza_customer'. As far as I can see, customer data isn't stored in localStorage, and that __hamza_customer key is not used anywhere else. If true, then it will never contain anything real. 
- maybe localStorage.__hamza_customer was once used, but it appears to no longer be 
- in that case, what to do in the onRehydrateStorage routine? Is it still needed?

https://www.notion.so/hamza-market/Wishlist-Bug-30e771beb31b4a79981bb47629f25f29?pvs=23