### PR TITLE
Order Bucket route

### DIFF
--- a/hamza-server/src/api/custom/order/customer-orders/route.ts
+++ b/hamza-server/src/api/custom/order/customer-orders/route.ts
@@ -34,14 +34,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         }
         else {
             if (handler.inputParams.buckets) {
-                const orders = []; //await orderService.getOrderBucketsForCustomer(handler.inputParams.customer_id);
+                const orders = await orderService.getCustomerOrders(handler.inputParams.customer_id);
                 res.status(200).json({ orders });
             } else {
-                const orders = {
-                    'ToPay': [],
-                    'ToReceive': []
-                    //.. etc
-                }; //await orderService.getOrdersForCustomer(handler.inputParams.customer_id);
+                const orders = await orderService.getCustomerOrderBuckets(handler.inputParams.customer_id);
                 res.status(200).json({ orders });
             }
         }

--- a/hamza-server/src/api/custom/order/customer-orders/route.ts
+++ b/hamza-server/src/api/custom/order/customer-orders/route.ts
@@ -1,4 +1,4 @@
-import type { MedusaRequest, MedusaResponse, Logger } from '@medusajs/medusa';
+import type { MedusaRequest, MedusaResponse, Logger, CustomerService } from '@medusajs/medusa';
 import OrderService from '../../../../services/order';
 import { RouteHandler } from '../../../route-handler';
 
@@ -27,18 +27,25 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
     await handler.handle(async () => {
         const orderService: OrderService = req.scope.resolve('orderService');
+        const customerService: CustomerService = req.scope.resolve('customerService');
 
         //validate 
         if (!req.query.customer_id?.length) {
-            res.status(400).json({message: 'customer_id is required'});
+            res.status(400).json({ message: 'customer_id is required' });
         }
         else {
-            if (handler.inputParams.buckets) {
-                const orders = await orderService.getCustomerOrders(handler.inputParams.customer_id);
-                res.status(200).json({ orders });
-            } else {
-                const orders = await orderService.getCustomerOrderBuckets(handler.inputParams.customer_id);
-                res.status(200).json({ orders });
+            //check for existence of customer 
+            if (!customerService.retrieve(handler.inputParams.customer_id)) {
+                res.status(404).json({ message: `Customer id ${handler.inputParams.customer_id} not found` });
+            }
+            else {
+                if (handler.inputParams.buckets) {
+                    const orders = await orderService.getCustomerOrderBuckets(handler.inputParams.customer_id);
+                    res.status(200).json({ orders });
+                } else {
+                    const orders = await orderService.getCustomerOrders(handler.inputParams.customer_id);
+                    res.status(200).json({ orders });
+                }
             }
         }
     });

--- a/hamza-server/src/services/__tests__/order.ts
+++ b/hamza-server/src/services/__tests__/order.ts
@@ -1,0 +1,39 @@
+import { MockManager, MockRepository } from 'medusa-test-utils';
+import OrderService from '../order';
+
+const mockOrders = [];
+
+const mockCustomers = [
+];
+
+const eventBusService = {
+    emit: jest.fn(),
+    withTransaction: function () {
+        return this;
+    },
+};
+
+describe('OrderService', () => {
+    let orderService: OrderService;
+    let orderRepository: any;
+
+    beforeAll(() => {
+        orderRepository = MockRepository({
+            find: jest.fn().mockResolvedValue(mockOrders),
+        });
+        orderService = new OrderService({
+            manager: MockManager,
+            orderRepository,
+            eventBusService,
+        });
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('get orders for nonexistent customer', async () => {
+        const orders = await orderService.getCustomerOrders('abc');
+        expect(orders.length).toEqual(0);
+    });
+});

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -23,6 +23,9 @@ type InjectDependencies = {
     lineItemService: LineItemService;
 };
 
+type OrderBucketList = 
+    {[key:string]: Order[]}
+
 export default class OrderService extends MedusaOrderService {
     static LIFE_TIME = Lifetime.SINGLETON; // default, but just to show how to change it
 
@@ -245,6 +248,14 @@ export default class OrderService extends MedusaOrderService {
         } catch (e) {
             this.logger.error(`Error fetching store from order: ${e}`);
         }
+    }
+
+    async getCustomerOrders(customerId: string): Promise<Order[]>{
+        return [];
+    }
+
+    async getCustomerOrderBuckets(customerId: string): Promise<OrderBucketList>{
+        return {};
     }
 
     private getPostCheckoutUpdateInventoryPromises(

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -255,7 +255,32 @@ export default class OrderService extends MedusaOrderService {
     }
 
     async getCustomerOrderBuckets(customerId: string): Promise<OrderBucketList>{
-        return {};
+        const buckets = await Promise.all([
+            this.getCustomerOrdersByStatus({paymentStatus: PaymentStatus.AWAITING}),
+            this.getCustomerOrdersByStatus({paymentStatus: PaymentStatus.CAPTURED, fulfillmentStatus: FulfillmentStatus.DOOP}),
+            this.getCustomerOrdersByStatus({paymentStatus: PaymentStatus.CAPTURED, fulfillmentStatus: FulfillmentStatus.SHIPPED}),
+            this.getCustomerOrdersByStatus({orderStatus: OrderStatus.COMPLETE, fulfillmentStatus: FulfillmentStatus.COMPLETE}),
+            this.getCustomerOrdersByStatus({orderStatus: OrderStatus.CANCELED}),
+            this.getCustomerOrdersByStatus({paymentStatus: PaymentStatus.REFUNDED})
+        ]);
+
+        const output = {
+            'ToPay': buckets[0],
+            'ToShip': buckets[1],
+            'ToReceive': buckets[2],
+            'Completed': buckets[3],
+            'Cancelled': buckets[4],
+            'Refunded': buckets[5]
+        };
+
+        return output;
+    }
+
+    private async getCustomerOrdersByStatus(statusParams: {
+            orderStatus?: OrderStatus, paymentStatus?: PaymentStatus, fulfillmentStatus?:FulfillmentStatus
+        }): Promise<Order[]> 
+    {
+        return [];
     }
 
     private getPostCheckoutUpdateInventoryPromises(

--- a/hamza-server/src/test/__mocks__/productService.ts
+++ b/hamza-server/src/test/__mocks__/productService.ts
@@ -1,7 +1,6 @@
 // __mocks__/productService.ts
 class ProductService {
     public async getAllProductsFromStoreWithPrices() {
-        console.log('Mock getAllProductsFromStoreWithPrices called');
         return [
             {
                 store_id: '',

--- a/hamza-server/src/test/__tests__/getProducts.test.js
+++ b/hamza-server/src/test/__tests__/getProducts.test.js
@@ -10,7 +10,6 @@ describe('All Products test suite', () => {
     it('should call mock product array', async () => {
         const products =
             await productService.getAllProductsFromStoreWithPrices();
-        console.log(products);
         expect(products).toEqual([
             {
                 store_id: '',


### PR DESCRIPTION
- added new route: GET custom/orders/customer-orders

The purpose of this route is to support the new customer orders display, in which orders are grouped into buckets "To Pay", "To Receive", etc. This will use server-side logic to group the orders into buckets for you, and return them already grouped. 

it works like this: 
?customer_id= (required) 
?buckets=true (or omit - if passed, then it will return the orders divided up into buckets; otherwise, it will just return an array of orders) 

output is in this form: 
{
 'ToPay': [... orders], 
 'ToShip': [..orders], 
... etc. 
}

- OrderService methods have been added to support this route 
- unit test stubs have been added, but need more work 
