### PR TITLE
Payment session fix

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -498,12 +498,34 @@ export async function deleteDiscount(cartId: string, code: string) {
         });
 }
 
-export async function createPaymentSessions(cartId: string) {
-    const headers = getMedusaHeaders(['cart']);
+export async function updatePaymentSession(cartId: string, paymentSessionId: string | undefined, providerId: string) {
+    console.log(`updatePaymentSession(${cartId}, ${paymentSessionId}, ${providerId})`)
+    if (paymentSessionId) {
+        try {
+            const response = await axios.put(
+                `${BACKEND_URL}/custom/payment-session`,
+                {
+                    cart_id: cartId,
+                    payment_session_id: paymentSessionId
+                }
+            );
+            return response.data;
+        } catch (error) {
+            console.log(error);
+            return null;
+        }
+    }
+}
 
+export async function createPaymentSessions(cartId: string, providerId: string = 'crypto') {
+    console.log(`createPaymentSessions(${cartId})`);
+    const headers = getMedusaHeaders(['cart']);
     return medusaClient.carts
         .createPaymentSessions(cartId, headers)
-        .then(({ cart }) => cart)
+        .then(({ cart }) => {
+            updatePaymentSession(cartId, cart?.payment_session?.id, providerId,);
+            return cart;
+        })
         .catch((err) => {
             console.log(err);
             return null;
@@ -518,11 +540,13 @@ export async function setPaymentSession({
     providerId: string;
 }) {
     const headers = getMedusaHeaders(['cart']);
-
     return medusaClient.carts
         .setPaymentSession(cartId, { provider_id: providerId }, headers)
+        //.createPaymentSessions(cartId, { provider_id: providerId })
         .then(({ cart }) => cart)
-        .catch((err) => medusaError(err));
+        .catch((err) => {
+            medusaError(err);
+        });
 }
 
 export async function completeCart(cartId: string) {

--- a/hamza-client/src/modules/checkout/actions.ts
+++ b/hamza-client/src/modules/checkout/actions.ts
@@ -173,7 +173,7 @@ export async function setPaymentMethod(providerId: string) {
         revalidateTag('cart');
         return cart;
     } catch (error: any) {
-        console.log(`IS THIS THE RUNNING ERROR`);
+        console.log(error);
         throw error;
     }
 }

--- a/hamza-server/src/api/custom/payment-session/route.ts
+++ b/hamza-server/src/api/custom/payment-session/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse, Logger } from '@medusajs/medusa';
+import PaymentSessionRepository from '@medusajs/medusa/dist/repositories/payment-session';
+import { RouteHandler } from '../../route-handler';
+
+/*
+ * This route does one thing: it updates the cart_id property of an existing payment session. 
+ * This exists to fix a bug in which the frontend creates a payment_session, but leaves the 
+ * cart_id null. 
+ */
+export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
+    const handler: RouteHandler = new RouteHandler(
+        req, res, 'PUT', '/custom/payment-session',
+        ['cart_id', 'payment_session_id']
+    );
+
+    await handler.handle(async () => {
+        let session = await PaymentSessionRepository.save([{
+            id: handler.inputParams.payment_session_id,
+            cart_id: handler.inputParams.cart_id
+        }]);
+
+        return res.status(200).send(session);
+    });
+};

--- a/http-client/local-dev.http
+++ b/http-client/local-dev.http
@@ -373,3 +373,12 @@ Content-Type: application/json
 ### GET Request to cancel order
 GET http://localhost:9000/custom/cancel-order/cart_01J3CF7DMR72ZS436EM0NYDCGW
 Content-Type: application/json
+
+
+### PUT cart_id to payment_session record 
+PUT http://localhost:9000/custom/payment-session
+Content-Type: application/json
+{
+  "cart_id": "cart_01J3M8J8V2SB9MQY6M13D0Y291",
+  "payment_session_id": "ps_01J3M8JRV4050QQCK59NE75MQZ"
+}


### PR DESCRIPTION
The problem is that payment_session records in the database are getting NULL for cart_id, even though the cart_id is being passed in. To make it worse, it _sometimes_ is non-null, and it's not clear at all why. 

I suspect this bug is inside of medusa. So therefore I've made a workaround. I added a new route to specifically update a payment_session record with a cart_id. And this is called from the client side each time a payment session is created. It seems to solve the problem. 

- new route: PUT /custom/payment_session 
- new client-side call (calls that API route) 
- createPaymentSession on client side modified to also update the cart id