### PR TITLE
Store whitelist at checkout

### DIFF
--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -54,10 +54,10 @@ declare global {
 const PaymentButton: React.FC<PaymentButtonProps> = ({ cart }) => {
     const notReady =
         !cart ||
-        !cart.shipping_address ||
-        !cart.billing_address ||
-        !cart.email ||
-        cart.shipping_methods.length < 1
+            !cart.shipping_address ||
+            !cart.billing_address ||
+            !cart.email ||
+            cart.shipping_methods.length < 1
             ? true
             : false;
 
@@ -300,7 +300,7 @@ const CryptoPaymentButton = ({
             updateCart.mutate(
                 { context: {} },
                 {
-                    onSuccess: ({}) => {
+                    onSuccess: ({ }) => {
                         //this calls the CartCompletion routine
                         completeCart.mutate(void 0, {
                             onSuccess: async ({ data, type }) => {
@@ -317,9 +317,16 @@ const CryptoPaymentButton = ({
                                     await cancelOrderFromCart();
                                 }
                             },
-                            onError: async ({}) => {
+                            onError: async (e) => {
                                 setSubmitting(false);
-                                setErrorMessage('Checkout was not completed');
+                                if (e.message?.indexOf('status code 401') >= 0) {
+                                    setErrorMessage('Customer not whitelisted');
+                                }
+                                else {
+                                    setErrorMessage('Checkout was not completed');
+                                }
+
+                                //TODO: this is a really bad way to do this 
                                 await cancelOrderFromCart();
                             },
                         });

--- a/hamza-server/src/migrations/2849489248999-Whitelist.ts
+++ b/hamza-server/src/migrations/2849489248999-Whitelist.ts
@@ -8,9 +8,14 @@ export class CreateWhiteListTable2849489248999 implements MigrationInterface {
         await queryRunner.query(
             `CREATE TABLE "whitelist_items" ("id"  character varying NOT NULL, "whitelist_id" character varying NOT NULL, "customer_address" character varying NOT NULL, CONSTRAINT "PK_whitelist_item" PRIMARY KEY ("id"))`
         );
+        await queryRunner.query(
+            `ALTER TABLE "whitelist_items"
+                ADD CONSTRAINT "fk_whitelist" FOREIGN KEY ("whitelist_id") REFERENCES "white_list"("id")`,
+        );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.dropTable('white_list');
+        await queryRunner.dropTable('whitelist_items');
     }
 }

--- a/hamza-server/src/migrations/2849489248999-Whitelist.ts
+++ b/hamza-server/src/migrations/2849489248999-Whitelist.ts
@@ -5,13 +5,13 @@ export class CreateWhiteListTable2849489248999 implements MigrationInterface {
         await queryRunner.query(
             `CREATE TABLE "white_list" ("id" character varying NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP WITH TIME ZONE, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "store_id" character varying NOT NULL, "wallet_address" character varying NOT NULL, CONSTRAINT "PK_be5fda3aac270b134ff9c21cdbn" PRIMARY KEY ("id"))`
         );
-        await queryRunner.query(
-            `CREATE TABLE "whitelist_items" ("id"  character varying NOT NULL, "whitelist_id" character varying NOT NULL, "customer_address" character varying NOT NULL, CONSTRAINT "PK_whitelist_item" PRIMARY KEY ("id"))`
-        );
-        await queryRunner.query(
-            `ALTER TABLE "whitelist_items"
-                ADD CONSTRAINT "fk_whitelist" FOREIGN KEY ("whitelist_id") REFERENCES "white_list"("id")`,
-        );
+        //await queryRunner.query(
+        //    `CREATE TABLE "whitelist_items" ("id"  character varying NOT NULL, "whitelist_id" character varying NOT NULL, "customer_address" character varying NOT NULL, CONSTRAINT "PK_whitelist_item" PRIMARY KEY ("id"))`
+        //);
+        //await queryRunner.query(
+        //    `ALTER TABLE "whitelist_items"
+        //        ADD CONSTRAINT "fk_whitelist" FOREIGN KEY ("whitelist_id") REFERENCES "white_list"("id")`,
+        //);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/hamza-server/src/migrations/2849489248999-Whitelist.ts
+++ b/hamza-server/src/migrations/2849489248999-Whitelist.ts
@@ -5,6 +5,9 @@ export class CreateWhiteListTable2849489248999 implements MigrationInterface {
         await queryRunner.query(
             `CREATE TABLE "white_list" ("id" character varying NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP WITH TIME ZONE, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "store_id" character varying NOT NULL, "wallet_address" character varying NOT NULL, CONSTRAINT "PK_be5fda3aac270b134ff9c21cdbn" PRIMARY KEY ("id"))`
         );
+        await queryRunner.query(
+            `CREATE TABLE "whitelist_items" ("id"  character varying NOT NULL, "whitelist_id" character varying NOT NULL, "customer_address" character varying NOT NULL, CONSTRAINT "PK_whitelist_item" PRIMARY KEY ("id"))`
+        );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/hamza-server/src/models/whitelist.ts
+++ b/hamza-server/src/models/whitelist.ts
@@ -1,6 +1,11 @@
-import { Entity, Column, ManyToOne, BeforeInsert } from 'typeorm';
+import {
+    Entity, Column, ManyToOne, BeforeInsert, OneToMany,
+    JoinColumn,
+    Unique,
+} from 'typeorm';
 import { SoftDeletableEntity } from '@medusajs/medusa';
 import { generateEntityId } from '@medusajs/medusa/dist/utils';
+import { BaseEntity } from '@medusajs/medusa';
 
 @Entity()
 export class WhiteList extends SoftDeletableEntity {
@@ -10,8 +15,28 @@ export class WhiteList extends SoftDeletableEntity {
     @Column()
     wallet_address: string;
 
+    @OneToMany(() => WhitelistItem, (whitelistItem) => whitelistItem.whitelist, {
+        onDelete: 'CASCADE',
+    })
+    items: WhitelistItem[];
+
     @BeforeInsert()
     private beforeInsert(): void {
         this.id = generateEntityId(this.id, 'whitelist');
     }
 }
+
+@Entity()
+@Unique(['whitelist_id', 'customer_address'])
+export class WhitelistItem extends BaseEntity {
+    @Column()
+    wishlist_id: string;
+
+    @ManyToOne(() => WhiteList, (whitelist) => whitelist.items)
+    @JoinColumn({ name: 'wishlist_id' })
+    whitelist: WhiteList;
+
+    @Column()
+    customer_address: string;
+}
+

--- a/hamza-server/src/models/whitelist.ts
+++ b/hamza-server/src/models/whitelist.ts
@@ -15,10 +15,10 @@ export class WhiteList extends SoftDeletableEntity {
     @Column()
     wallet_address: string;
 
-    @OneToMany(() => WhitelistItem, (whitelistItem) => whitelistItem.whitelist, {
-        onDelete: 'CASCADE',
-    })
-    items: WhitelistItem[];
+    //@OneToMany(() => WhitelistItem, (whitelistItem) => whitelistItem.whitelist, {
+    //    onDelete: 'CASCADE',
+    //})
+    //items: WhitelistItem[];
 
     @BeforeInsert()
     private beforeInsert(): void {
@@ -26,6 +26,7 @@ export class WhiteList extends SoftDeletableEntity {
     }
 }
 
+/*
 @Entity()
 @Unique(['whitelist_id', 'customer_address'])
 export class WhitelistItem extends BaseEntity {
@@ -38,5 +39,11 @@ export class WhitelistItem extends BaseEntity {
 
     @Column()
     customer_address: string;
+
+    @BeforeInsert()
+    private beforeInsert(): void {
+        this.id = generateEntityId(this.id, 'wi');
+    }
 }
+*/
 

--- a/hamza-server/src/models/whitelist.ts
+++ b/hamza-server/src/models/whitelist.ts
@@ -30,10 +30,10 @@ export class WhiteList extends SoftDeletableEntity {
 @Unique(['whitelist_id', 'customer_address'])
 export class WhitelistItem extends BaseEntity {
     @Column()
-    wishlist_id: string;
+    whitelist_id: string;
 
     @ManyToOne(() => WhiteList, (whitelist) => whitelist.items)
-    @JoinColumn({ name: 'wishlist_id' })
+    @JoinColumn({ name: 'whitelist_id' })
     whitelist: WhiteList;
 
     @Column()

--- a/hamza-server/src/services/cart.ts
+++ b/hamza-server/src/services/cart.ts
@@ -24,7 +24,7 @@ export default class CartService extends MedusaCartService {
         config: { validateSalesChannels: boolean }
     ): Promise<void> {
         const cart: Cart = await this.retrieve(cartId, {
-            relations: ['customer'],
+            relations: ['customer', 'customer.walletAddresses'],
         });
 
         //get preferred currency from customer

--- a/hamza-server/src/services/whitelist.ts
+++ b/hamza-server/src/services/whitelist.ts
@@ -31,13 +31,13 @@ export default class WhiteListService extends TransactionBaseService {
         return;
     }
 
-    async getByStore(storeId: string, walletAddress: string) {
-        const whitelist = await this.whitelistRepository_.findOne({
+    async getByStore(storeId: string, walletAddress: string): Promise<WhiteList> {
+        return await this.whitelistRepository_.findOne({
             where: {
                 store_id: storeId,
                 wallet_address: walletAddress
             },
-            relations: ['customers']
+            relations: ['items']
         });
     }
 }

--- a/hamza-server/src/services/whitelist.ts
+++ b/hamza-server/src/services/whitelist.ts
@@ -1,12 +1,8 @@
 import { TransactionBaseService, Logger } from '@medusajs/medusa';
-import ConfirmationTokenRepository from '../repositories/confirmation-token';
 import CustomerRepository from '../repositories/customer';
-import moment from 'moment';
-import { ethers } from 'ethers';
-import SmtpMailService from './smtp-mail';
-import dotenv from 'dotenv';
-import { WhiteListRepository } from '..//repositories/whitelist';
-dotenv.config();
+import { WhiteListRepository } from '../repositories/whitelist';
+import { WhiteList } from '../models/whitelist';
+
 
 export default class WhiteListService extends TransactionBaseService {
     protected readonly customerRepository_: typeof CustomerRepository;
@@ -20,15 +16,28 @@ export default class WhiteListService extends TransactionBaseService {
         this.logger = container.logger;
     }
 
-    async create(store_id: string, wallet_address: string) {
+    async create(storeId: string, walletAddress: string) {
         return await this.whitelistRepository_.save({
-            store_id,
-            wallet_address,
+            store_id: storeId,
+            wallet_address: walletAddress
         });
     }
 
-    async remove(store_id: string, wallet_address: string) {
-        await this.whitelistRepository_.delete({ store_id, wallet_address });
+    async remove(storeId: string, walletAddress: string) {
+        await this.whitelistRepository_.delete({
+            store_id: storeId,
+            wallet_address: walletAddress
+        });
         return;
+    }
+
+    async getByStore(storeId: string, walletAddress: string) {
+        const whitelist = await this.whitelistRepository_.findOne({
+            where: {
+                store_id: storeId,
+                wallet_address: walletAddress
+            },
+            relations: ['customers']
+        });
     }
 }

--- a/hamza-server/src/strategies/price-selection.ts
+++ b/hamza-server/src/strategies/price-selection.ts
@@ -105,7 +105,7 @@ export default class PriceSelectionStrategy extends AbstractPriceSelectionStrate
             let prices = v.prices;
 
             //convert all currency prices according to base price
-            const baseCurrency = store?.default_currency_code;
+            /*const baseCurrency = store?.default_currency_code;
             const baseAmount = prices.find((p) => p.currency_code === baseCurrency)?.amount;
             if (baseAmount && baseCurrency) {
                 for (let n = 0; n < prices.length; n++) {
@@ -115,7 +115,7 @@ export default class PriceSelectionStrategy extends AbstractPriceSelectionStrate
                         toCurrency: prices[n].currency_code
                     });
                 }
-            }
+            }*/
 
             //if preferred currency, filter out the non-matchers
             if (preferredCurrencyId) {


### PR DESCRIPTION
if the appropriate .env variable is set on hamza-server side, then whitelisting by store is required at checkout time, in order to check out. Whitelisting is done by adding an entry to the white_list table with the wallet_address of the whitelisted customer and a store_id of the store. 

When whitelisting is turned on, failure to be on the whitelist at checkout will result in checking failing. CompleteCart will fail with a 401 (unauthorized). 