### PR TITLE
Cancel shenanigans

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -350,11 +350,10 @@ export async function cancelOrder(order_id: string) {
         const response = await axios.post(
             `${BACKEND_URL}/custom/order/cancel`,
             {
-                params: {
-                    order_id: order_id,
-                },
+                order_id
             }
         );
+
         return response;
     } catch (error) {
         console.error('Error cancelling order:', error);

--- a/hamza-client/src/modules/order/templates/all.tsx
+++ b/hamza-client/src/modules/order/templates/all.tsx
@@ -9,6 +9,7 @@ import { Box, Button, FormControl, FormErrorMessage, Modal, ModalBody, ModalClos
 import OrderCard from '@modules/account/components/order-card';
 import LocalizedClientLink from '@modules/common/components/localized-client-link';
 import { Textarea } from '@medusajs/ui';
+
 type OrderType = {
     id: string;
     cart: any;
@@ -16,6 +17,7 @@ type OrderType = {
     status: string;
     // include other order properties here
 };
+
 interface OrderState {
     Processing: OrderType[];
     Shipped: OrderType[];
@@ -23,6 +25,9 @@ interface OrderState {
     Cancelled: OrderType[];
     Refunded: OrderType[];
 }
+
+const MIN_CANCEL_REASON_LENGTH = 30;
+
 const All = ({ orders }: { orders: any[] }) => {
     const [customerId, setCustomerId] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -105,9 +110,9 @@ const All = ({ orders }: { orders: any[] }) => {
         setIsLoading(false);
     };
 
-    //TODO: this is duplicated code; should be dried
+    //TODO: this is duplicated code (3x); should be DRYed (likewise with the modal itself)
     const handleCancel = async () => {
-        if (!cancelReason) {
+        if ((cancelReason?.length ?? 0) < MIN_CANCEL_REASON_LENGTH) {
             setIsAttemptedSubmit(true);
             return;
         }
@@ -685,7 +690,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                     setCancelReason(e.target.value)
                                 }
                             />
-                            {!cancelReason && isAttemptedSubmit && (
+                            {((cancelReason?.length ?? 0) < MIN_CANCEL_REASON_LENGTH) && isAttemptedSubmit && (
                                 <FormErrorMessage>
                                     Cancellation reason is required.
                                 </FormErrorMessage>

--- a/hamza-client/src/modules/order/templates/all.tsx
+++ b/hamza-client/src/modules/order/templates/all.tsx
@@ -192,7 +192,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                     </Button>
                                                 </LocalizedClientLink>
                                                 {orderStatuses[
-                                                    order.cart_id
+                                                    order.id
                                                 ] === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
@@ -253,7 +253,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                     pb={'6'}
                                 >
                                     {/*<div className="p-4 bg-gray-700">*/}
-                                    {/*    Cart ID {order.cart_id} - Total Items:{' '}*/}
+                                    {/*    Cart ID {order.id} - Total Items:{' '}*/}
                                     {/*    {order.cart?.items?.length || 0}*/}
                                     {/*    <span*/}
                                     {/*        className="pl-2 text-blue-400 underline underline-offset-1 cursor-pointer"*/}
@@ -297,7 +297,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                     </Button>
                                                 </LocalizedClientLink>
                                                 {orderStatuses[
-                                                    order.cart_id
+                                                    order.id
                                                 ] === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
@@ -403,7 +403,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                     </Button>
                                                 </LocalizedClientLink>
                                                 {orderStatuses[
-                                                    order.cart_id
+                                                    order.id
                                                 ] === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
@@ -509,7 +509,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                     </Button>
                                                 </LocalizedClientLink>
                                                 {orderStatuses[
-                                                    order.cart_id
+                                                    order.id
                                                 ] === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
@@ -615,7 +615,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                     </Button>
                                                 </LocalizedClientLink>
                                                 {orderStatuses[
-                                                    order.cart_id
+                                                    order.id
                                                 ] === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"

--- a/hamza-client/src/modules/order/templates/all.tsx
+++ b/hamza-client/src/modules/order/templates/all.tsx
@@ -13,6 +13,7 @@ type OrderType = {
     id: string;
     cart: any;
     cart_id: string;
+    status: string;
     // include other order properties here
 };
 interface OrderState {
@@ -37,9 +38,6 @@ const All = ({ orders }: { orders: any[] }) => {
         Cancelled: [],
         Refunded: [],
     });
-    const [orderStatuses, setOrderStatuses] = useState<{
-        [key: string]: string;
-    }>({});
 
     const openCancelModal = (orderId: string) => {
         setSelectedOrderId(orderId);
@@ -117,10 +115,6 @@ const All = ({ orders }: { orders: any[] }) => {
 
         try {
             await cancelOrder(selectedOrderId);
-            setOrderStatuses((prevStatuses) => ({
-                ...prevStatuses,
-                [selectedOrderId]: 'canceled',
-            }));
             setIsModalOpen(false);
         } catch (error) {
             console.error('Error cancelling order: ', error);
@@ -191,9 +185,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                         See details
                                                     </Button>
                                                 </LocalizedClientLink>
-                                                {orderStatuses[
-                                                    order.id
-                                                ] === 'canceled' ? (
+                                                {order.status === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
                                                         ml={4}
@@ -296,9 +288,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                         See details
                                                     </Button>
                                                 </LocalizedClientLink>
-                                                {orderStatuses[
-                                                    order.id
-                                                ] === 'canceled' ? (
+                                                {order.status === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
                                                         ml={4}
@@ -402,9 +392,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                         See details
                                                     </Button>
                                                 </LocalizedClientLink>
-                                                {orderStatuses[
-                                                    order.id
-                                                ] === 'canceled' ? (
+                                                {order.status === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
                                                         ml={4}
@@ -508,9 +496,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                         See details
                                                     </Button>
                                                 </LocalizedClientLink>
-                                                {orderStatuses[
-                                                    order.id
-                                                ] === 'canceled' ? (
+                                                {order.status === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
                                                         ml={4}
@@ -614,9 +600,7 @@ const All = ({ orders }: { orders: any[] }) => {
                                                         See details
                                                     </Button>
                                                 </LocalizedClientLink>
-                                                {orderStatuses[
-                                                    order.id
-                                                ] === 'canceled' ? (
+                                                {order.status === 'canceled' ? (
                                                     <Button
                                                         colorScheme="red"
                                                         ml={4}

--- a/hamza-server/src/api/custom/order/cancel/route.ts
+++ b/hamza-server/src/api/custom/order/cancel/route.ts
@@ -19,6 +19,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         const order = await orderService.cancelOrder(
             handler.inputParams.order_id
         );
+        handler.logger.debug(`Order ${handler.inputParams.order_id} cancelled.`);
 
         res.status(200).json({ order });
     });

--- a/hamza-server/src/api/custom/order/cancel/route.ts
+++ b/hamza-server/src/api/custom/order/cancel/route.ts
@@ -19,8 +19,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         const order = await orderService.cancelOrder(
             handler.inputParams.order_id
         );
-        handler.logger.debug(`Order ${handler.inputParams.order_id} cancelled.`);
 
+        handler.logger.debug(`Order ${handler.inputParams.order_id} cancelled.`);
         res.status(200).json({ order });
     });
 };


### PR DESCRIPTION
Improved the Order Cancellation situation. Still a few things to do but it submits the form, and cancels the order. 

I'm not sure why orders are keying off of "cart_id" everywhere, but they should be done by order id. We do not need to give a shit about what cart they were in, after the order has been placed. 