### PR TITLE
shortened text of buttons so that they don't overflow

### DIFF
--- a/hamza-client/src/modules/account/components/review-page/index.tsx
+++ b/hamza-client/src/modules/account/components/review-page/index.tsx
@@ -199,7 +199,7 @@ const ReviewPage = ({ region }: { region: Region }) => {
                                             }
                                             colorScheme="green"
                                         >
-                                            Update Review
+                                            Edit
                                         </Button>
                                     )}
                                 </div>
@@ -273,7 +273,7 @@ const ReviewPage = ({ region }: { region: Region }) => {
                                             }
                                             colorScheme="green"
                                         >
-                                            Write Review
+                                            Review
                                         </Button>
                                     </div>
                                 </CardBody>


### PR DESCRIPTION
The text was overflowing off the buttons, I fixed that using the ingenious method called 'making the text shorter' cause you know, I'm a stable genius. Check this out: 
 - person
 - woman 
 - man
 - camera
 - tv