### PR TITLE
buckydrop status error: 6 is shipped

### DIFF
--- a/hamza-server/src/services/buckydrop.ts
+++ b/hamza-server/src/services/buckydrop.ts
@@ -289,7 +289,7 @@ export default class BuckydropService extends TransactionBaseService {
                 //get the order status
                 if (orderDetail) {
                     const status =
-                        orderDetail.orderDetails?.data?.poOrderList[0]
+                        orderDetail?.data?.poOrderList[0]
                             ?.orderStatus;
                     if (status) {
                         //translate the status

--- a/hamza-server/src/services/buckydrop.ts
+++ b/hamza-server/src/services/buckydrop.ts
@@ -327,7 +327,7 @@ export default class BuckydropService extends TransactionBaseService {
                             case 6:
                                 order.status = OrderStatus.PENDING;
                                 order.fulfillment_status =
-                                    FulfillmentStatus.NOT_FULFILLED;
+                                    FulfillmentStatus.SHIPPED;
                                 break;
                             case 7:
                                 order.status = OrderStatus.PENDING;


### PR DESCRIPTION
Wrong status for bucky order details: 6 should mean 'shipped'