### PR TITLE
New bucky order handling

### DIFF
--- a/hamza-server/src/api/custom/bucky/orders/route.ts
+++ b/hamza-server/src/api/custom/bucky/orders/route.ts
@@ -1,4 +1,4 @@
-import { MedusaRequest, MedusaResponse, OrderService, ShippingOptionPriceType, ShippingOptionService } from '@medusajs/medusa';
+import { MedusaRequest, MedusaResponse, Order, OrderService, ShippingOptionPriceType, ShippingOptionService } from '@medusajs/medusa';
 import { RouteHandler } from '../../../route-handler';
 import BuckydropService from 'src/services/buckydrop';
 
@@ -16,5 +16,35 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         const orders = await buckydropService.getPendingOrders();
 
         res.status(200).json({ orders });
+    });
+};
+
+export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
+    const buckydropService: BuckydropService = req.scope.resolve('buckydropService');
+
+    const handler: RouteHandler = new RouteHandler(
+        req,
+        res,
+        'GET',
+        '/admin/custom/bucky/orders',
+        ['order']
+    );
+
+    await handler.handle(async () => {
+        if (!handler.requireParam('order'))
+            return;
+
+        const orderId = handler.inputParams.order;
+        const orders = await buckydropService.getPendingOrders();
+        let order: Order = orders.find((o) => o.id === orderId);
+
+        if (!order) {
+            res.status(400).json({ message: `Order ${orderId} isn't valid or isn't a buckydrop pending order` });
+        }
+
+        handler.logger.debug(`Processing order ${orderId}`);
+        order = await buckydropService.processPendingOrder(order.id);
+
+        res.status(200).json({ order });
     });
 };

--- a/hamza-server/src/api/custom/bucky/orders/route.ts
+++ b/hamza-server/src/api/custom/bucky/orders/route.ts
@@ -1,0 +1,20 @@
+import { MedusaRequest, MedusaResponse, OrderService, ShippingOptionPriceType, ShippingOptionService } from '@medusajs/medusa';
+import { RouteHandler } from '../../../route-handler';
+import BuckydropService from 'src/services/buckydrop';
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+    const buckydropService: BuckydropService = req.scope.resolve('buckydropService');
+
+    const handler: RouteHandler = new RouteHandler(
+        req,
+        res,
+        'GET',
+        '/admin/custom/bucky/orders'
+    );
+
+    await handler.handle(async () => {
+        const orders = await buckydropService.getPendingOrders();
+
+        res.status(200).json({ orders });
+    });
+};

--- a/hamza-server/src/api/custom/bucky/track/route.ts
+++ b/hamza-server/src/api/custom/bucky/track/route.ts
@@ -19,14 +19,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     await handler.handle(async () => {
         const orderId = handler.inputParams.order;
 
-        //const order: Order = await orderService.retrieve(orderId);
-        //const metadata = JSON.parse(order.bucky_metadata);
-
-        //const orderNo = metadata.data.shopOrderNo;
-        //c/onsole.log('orderNo is ', orderNo);
-
         const output = await buckyService.reconcileOrderStatus(orderId);
-        output.bucky_metadata = JSON.parse(output.bucky_metadata);
 
         return res
             .status(201)

--- a/hamza-server/src/api/custom/checkout/route.ts
+++ b/hamza-server/src/api/custom/checkout/route.ts
@@ -55,14 +55,20 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         'escrow_contract_address'
     ]);
 
-    await handler.handle(async () => {
-        await orderService.finalizeCheckout(
-            //handler.inputParams.cart_products,
-            handler.inputParams.cart_id,
-            handler.inputParams.transaction_id,
-            handler.inputParams.payer_address,
-            handler.inputParams.escrow_contract_address
-        );
-        res.send(true);
-    });
+    try {
+        await handler.handle(async () => {
+            await orderService.finalizeCheckout(
+                //handler.inputParams.cart_products,
+                handler.inputParams.cart_id,
+                handler.inputParams.transaction_id,
+                handler.inputParams.payer_address,
+                handler.inputParams.escrow_contract_address
+            );
+            res.send(true);
+        });
+    }
+    catch (e: any) {
+        handler.logger.error(e);
+        res.send(false);
+    }
 };

--- a/hamza-server/src/api/custom/config/route.ts
+++ b/hamza-server/src/api/custom/config/route.ts
@@ -3,7 +3,7 @@ import { RouteHandler } from '../../route-handler';
 import { Config } from '../../../config';
 
 /*This route does one thing: it updates the checkoutMode property when CartCompletionStrategy runs, based off the
- * environment variable CHECKOUT_MODE. This is a simple GET request that returns the payment mode. */
+ * environment variable     . This is a simple GET request that returns the payment mode. */
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     const handler: RouteHandler = new RouteHandler(

--- a/hamza-server/src/api/custom/order/customer-order/route.ts
+++ b/hamza-server/src/api/custom/order/customer-order/route.ts
@@ -37,8 +37,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
                 });
             } else {
                 //enforce security
-                // if (!handler.enforceCustomerId(customerId))
-                //     return;
+                if (!handler.enforceCustomerId(customerId))
+                    return;
 
                 if (handler.inputParams.bucket) {
                     const bucketValue = parseInt(handler.inputParams.bucket);

--- a/hamza-server/src/index.d.ts
+++ b/hamza-server/src/index.d.ts
@@ -51,13 +51,13 @@ export declare module '@medusajs/medusa/dist/models/product' {
         store?: Store;
         store_id: string;
         reviews: ProductReview[];
-        bucky_metadata?: string;
+        bucky_metadata?: Record<string, unknown>;
     }
 }
 
 export declare module '@medusajs/medusa/dist/models/product-variant' {
     declare interface ProductVariant {
-        bucky_metadata?: string;
+        bucky_metadata?: Record<string, unknown>;
     }
 }
 

--- a/hamza-server/src/index.d.ts
+++ b/hamza-server/src/index.d.ts
@@ -68,7 +68,6 @@ export declare module '@medusajs/medusa/dist/model/order' {
         massmarket_order_id?: string;
         massmarket_ttl?: number;
         massmarket_amount?: string;
-        bucky_order_no?: string;
-        bucky_partner_order_no?: string;
+        bucky_metadata?: Record<string, unknown>;
     }
 }

--- a/hamza-server/src/migrations/3595867849494-BuckyOrder.ts
+++ b/hamza-server/src/migrations/3595867849494-BuckyOrder.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class BuckyOrder3595867849494 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `ALTER TABLE "order" ADD COLUMN "bucky_metadata" VARCHAR NULL`
+            `ALTER TABLE "order" ADD COLUMN "bucky_metadata" jsonb`
         );
     }
 

--- a/hamza-server/src/migrations/5828595666725-BuckyProduct.ts
+++ b/hamza-server/src/migrations/5828595666725-BuckyProduct.ts
@@ -3,10 +3,10 @@ import { MigrationInterface, QueryRunner, Table } from 'typeorm';
 export class BuckyProduct5828595666725 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `ALTER TABLE "product" ADD "bucky_metadata" character varying`,
+            `ALTER TABLE "product" ADD "bucky_metadata" jsonb`,
         );
         await queryRunner.query(
-            `ALTER TABLE "product_variant" ADD "bucky_metadata" character varying`,
+            `ALTER TABLE "product_variant" ADD "bucky_metadata" jsonb`,
         );
     }
 

--- a/hamza-server/src/models/order.ts
+++ b/hamza-server/src/models/order.ts
@@ -22,6 +22,6 @@ export class Order extends MedusaOrder {
     @Column()
     massmarket_amount?: string;
 
-    @Column()
-    bucky_metadata?: string;
+    @Column('jsonb')
+    bucky_metadata?: Record<string, unknown>;
 }

--- a/hamza-server/src/models/product-variant.ts
+++ b/hamza-server/src/models/product-variant.ts
@@ -7,6 +7,6 @@ import {
 @Entity()
 export class ProductVariant extends MedusaProductVariant {
 
-    @Column()
-    bucky_metadata?: string;
+    @Column('jsonb')
+    bucky_metadata?: Record<string, unknown>;
 }

--- a/hamza-server/src/models/product.ts
+++ b/hamza-server/src/models/product.ts
@@ -28,6 +28,6 @@ export class Product extends MedusaProduct {
     @Column()
     massmarket_prod_id?: string;
 
-    @Column()
-    bucky_metadata?: string;
+    @Column('jsonb')
+    bucky_metadata?: Record<string, unknown>;
 }

--- a/hamza-server/src/services/buckydrop.ts
+++ b/hamza-server/src/services/buckydrop.ts
@@ -8,6 +8,7 @@ import {
     OrderStatus,
     FulfillmentStatus,
     CustomerService,
+    ProductVariant,
 } from '@medusajs/medusa';
 import ProductService from '../services/product';
 import OrderService from '../services/order';
@@ -17,6 +18,7 @@ import { PriceConverter } from '../strategies/price-selection';
 import {
     BuckyClient,
     IBuckyShippingCostRequest,
+    ICreateBuckyOrderProduct,
 } from '../buckydrop/bucky-client';
 import { CreateProductInput as MedusaCreateProductInput } from '@medusajs/medusa/dist/types/product';
 import { UpdateProductInput as MedusaUpdateProductInput } from '@medusajs/medusa/dist/types/product';
@@ -275,6 +277,84 @@ export default class BuckydropService extends TransactionBaseService {
         product: Product
     ): Promise<number> {
         return 0;
+    }
+
+    async processPendingOrder(orderId: string): Promise<Order> {
+        const order: Order = await this.orderRepository_.findOne({
+            where: { id: orderId }
+        });
+
+        if (order && order?.cart_id && order.bucky_metadata) {
+
+            //get cart 
+            const cart: Cart = await this.cartService_.retrieve(
+                order.cart_id,
+                {
+                    relations: ['billing_address.country', 'customer'],
+                }
+            );
+
+            //get data to send to bucky
+            const { variants, quantities } = await
+                this.orderService_.getBuckyProductVariantsFromOrder(order);
+
+            //create list of products
+            const productList: ICreateBuckyOrderProduct[] = [];
+            for (let n = 0; n < variants.length; n++) {
+                const prodMetadata: any = JSON.parse(
+                    variants[n].product.bucky_metadata
+                );
+                const varMetadata: any = JSON.parse(
+                    variants[n].bucky_metadata
+                );
+
+                productList.push({
+                    spuCode: prodMetadata?.detail.spuCode,
+                    skuCode: varMetadata.skuCode,
+                    productCount: quantities[n],
+                    platform: prodMetadata?.detail?.platform,
+                    productPrice:
+                        prodMetadata?.detail?.proPrice?.price ??
+                        prodMetadata?.detail?.price?.price ??
+                        0,
+                    productName: prodMetadata?.detail?.goodsName,
+                });
+            }
+
+            //create order via Bucky API 
+            this.logger.info(`Creating buckydrop order for ${orderId}`);
+            const output: any = await this.buckyClient.createOrder({
+                partnerOrderNo: order.id.replace('_', ''),
+                //partnerOrderNoName: order.id, //TODO: what go here?
+                country: cart.billing_address.country.name ?? '', //TODO: what format?
+                countryCode: cart.billing_address.country.iso_2 ?? '', //TODO: what format?
+                province: cart.billing_address.province ?? '',
+                city: cart.billing_address.city ?? '',
+                detailAddress:
+                    `${cart.billing_address.address_1 ?? ''} ${cart.billing_address.address_2 ?? ''}`.trim(),
+                postCode: cart.billing_address.postal_code,
+                contactName:
+                    `${cart.billing_address.first_name ?? ''} ${cart.billing_address.last_name ?? ''}`.trim(),
+                contactPhone: cart.billing_address.phone?.length
+                    ? cart.billing_address.phone
+                    : '0809997747',
+                email: cart.email?.length
+                    ? cart.email
+                    : cart.customer.email,
+                orderRemark: '',
+                productList,
+            });
+            this.logger.info(`Created buckydrop order for ${orderId}`);
+
+            //save the output 
+            order.bucky_metadata = JSON.stringify(output);
+            await this.orderRepository_.save(order);
+            this.logger.info(`Saved order ${orderId}`);
+        } else {
+            this.logger.warn(`Allegedly pending bucky drop order ${orderId} is either not found, has no cart, or has no buckydrop metadata`);
+        }
+
+        return order;
     }
 
     async reconcileOrderStatus(orderId: string): Promise<Order> {

--- a/hamza-server/src/services/buckydrop.ts
+++ b/hamza-server/src/services/buckydrop.ts
@@ -27,7 +27,7 @@ import { IsNull, Not, FindManyOptions } from 'typeorm';
 
 type CreateProductInput = MedusaCreateProductInput & {
     store_id: string;
-    bucky_metadata?: string;
+    bucky_metadata?: Record<string, unknown>;
 };
 
 const SHIPPING_COST_MIN: number = parseInt(
@@ -182,12 +182,10 @@ export default class BuckydropService extends TransactionBaseService {
             //generate input for each product in cart that is bucky
             for (let item of cart.items) {
                 if (item.variant.bucky_metadata?.length) {
-                    const variantMetadata = JSON.parse(
-                        item.variant.bucky_metadata
-                    );
-                    const productMetadata = JSON.parse(
-                        item.variant.product.bucky_metadata
-                    );
+                    const variantMetadata: any =
+                        item.variant.bucky_metadata;
+                    const productMetadata: any =
+                        item.variant.product.bucky_metadata;
                     input.productList.push({
                         length: variantMetadata.length ?? 100,
                         width: variantMetadata.width ?? 100,
@@ -296,12 +294,8 @@ export default class BuckydropService extends TransactionBaseService {
             //create list of products
             const productList: ICreateBuckyOrderProduct[] = [];
             for (let n = 0; n < variants.length; n++) {
-                const prodMetadata: any = JSON.parse(
-                    variants[n].product.bucky_metadata
-                );
-                const varMetadata: any = JSON.parse(
-                    variants[n].bucky_metadata
-                );
+                const prodMetadata: any = variants[n].product.bucky_metadata;
+                const varMetadata: any = variants[n].bucky_metadata;
 
                 productList.push({
                     spuCode: prodMetadata?.detail.spuCode,
@@ -670,7 +664,7 @@ export default class BuckydropService extends TransactionBaseService {
                 sales_channels: salesChannels.map((sc) => {
                     return { id: sc };
                 }),
-                bucky_metadata: JSON.stringify(metadata),
+                bucky_metadata: metadata,
                 variants: await this.mapVariants(productDetails),
             };
 

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -517,20 +517,10 @@ export default class OrderService extends MedusaOrderService {
                     await this.getBuckyProductVariantsFromOrder(order);
                 if (variants?.length) {
 
-                    let output = {};
-                    if (BUCKY_ORDER_CREATION_MODE == 'old') {
-
-                    }
-                    else {
-                        output = { status: 'pending' };
-                    }
-
-                    //TODO: if not success, need to take some action
-                    order.bucky_metadata = JSON.stringify(output);
+                    order.bucky_metadata = { status: 'pending' };
                     await this.orderRepository_.save(order);
 
                     this.logger.debug('BUCKY CREATED ORDER');
-                    this.logger.debug(JSON.stringify(output));
                 }
             }
         } catch (e) {

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -47,6 +47,9 @@ type InjectDependencies = {
 
 type OrderBucketList = { [key: string]: Order[] };
 
+
+const BUCKY_ORDER_CREATION_MODE: 'old' | 'new' = 'new';
+
 export default class OrderService extends MedusaOrderService {
     static LIFE_TIME = Lifetime.SINGLETON; // default, but just to show how to change it
 
@@ -207,7 +210,7 @@ export default class OrderService extends MedusaOrderService {
 
         //do buckydrop order creation
         if (process.env.BUCKY_ENABLE_PURCHASE)
-            await this.doBuckydropOrderCreation(cartId, orders);
+            await this.processBuckydropOrders(cartId, orders);
 
         //calls to update inventory
         //const inventoryPromises =
@@ -242,83 +245,6 @@ export default class OrderService extends MedusaOrderService {
         }
 
         return orders;
-    }
-
-    private async doBuckydropOrderCreation(
-        cartId: string,
-        orders: Order[]
-    ): Promise<void> {
-        try {
-            for (const order of orders) {
-                const { variants, quantities } =
-                    await this.getBuckyProductVariantsFromOrder(order);
-                if (variants?.length) {
-                    const productList: ICreateBuckyOrderProduct[] = [];
-
-                    for (let n = 0; n < variants.length; n++) {
-                        const prodMetadata: any = JSON.parse(
-                            variants[n].product.bucky_metadata
-                        );
-                        const varMetadata: any = JSON.parse(
-                            variants[n].bucky_metadata
-                        );
-
-                        productList.push({
-                            spuCode: prodMetadata?.detail.spuCode,
-                            skuCode: varMetadata.skuCode,
-                            productCount: quantities[n],
-                            platform: prodMetadata?.detail?.platform,
-                            productPrice:
-                                prodMetadata?.detail?.proPrice?.price ??
-                                prodMetadata?.detail?.price?.price ??
-                                0,
-                            productName: prodMetadata?.detail?.goodsName,
-                        });
-                    }
-
-                    const cart: Cart = await this.cartService_.retrieve(
-                        cartId,
-                        {
-                            relations: ['billing_address.country', 'customer'],
-                        }
-                    );
-
-                    this.logger.debug('cart.email: ' + cart.email);
-
-                    //TODO: replace this with a BuckyService call, and get rid of buckyClient
-                    const output = await this.buckyClient.createOrder({
-                        partnerOrderNo: order.id.replace('_', ''),
-                        //partnerOrderNoName: order.id, //TODO: what go here?
-                        country: cart.billing_address.country.name ?? '', //TODO: what format?
-                        countryCode: cart.billing_address.country.iso_2 ?? '', //TODO: what format?
-                        province: cart.billing_address.province ?? '',
-                        city: cart.billing_address.city ?? '',
-                        detailAddress:
-                            `${cart.billing_address.address_1 ?? ''} ${cart.billing_address.address_2 ?? ''}`.trim(),
-                        postCode: cart.billing_address.postal_code,
-                        contactName:
-                            `${cart.billing_address.first_name ?? ''} ${cart.billing_address.last_name ?? ''}`.trim(),
-                        contactPhone: cart.billing_address.phone?.length
-                            ? cart.billing_address.phone
-                            : '0809997747',
-                        email: cart.email?.length
-                            ? cart.email
-                            : cart.customer.email,
-                        orderRemark: '',
-                        productList,
-                    });
-
-                    //TODO: if not success, need to take some action
-                    order.bucky_metadata = JSON.stringify(output);
-                    await this.orderRepository_.save(order);
-
-                    this.logger.debug('BUCKY CREATED ORDER');
-                    this.logger.debug(JSON.stringify(output));
-                }
-            }
-        } catch (e) {
-            this.logger.error(`Failed to create buckydrop order for ${cartId}`);
-        }
     }
 
     async cancelOrder(orderId: string) {
@@ -433,93 +359,6 @@ export default class OrderService extends MedusaOrderService {
         }
 
         return [];
-    }
-
-    private async getCustomerOrdersByStatus(
-        customerId: string,
-        statusParams: {
-            orderStatus?: OrderStatus;
-            paymentStatus?: PaymentStatus;
-            fulfillmentStatus?: FulfillmentStatus;
-        }
-    ): Promise<Order[]> {
-        const where: {
-            customer_id: string;
-            status?: any;
-            payment_status?: any;
-            fulfillment_status?: any;
-        } = {
-            customer_id: customerId,
-            status: Not(OrderStatus.ARCHIVED),
-        };
-
-        if (statusParams.orderStatus) {
-            where.status = statusParams.orderStatus;
-        }
-
-        if (statusParams.paymentStatus) {
-            where.payment_status = statusParams.paymentStatus;
-        }
-
-        if (statusParams.fulfillmentStatus) {
-            where.fulfillment_status = statusParams.fulfillmentStatus;
-        }
-
-        return await this.orderRepository_.find({
-            where,
-            relations: [
-                'items',
-                'store',
-                'shipping_address',
-                'customer',
-                'items.variant.product',
-            ],
-        });
-    }
-
-    private getPostCheckoutUpdateInventoryPromises(
-        cartProductsJson: string
-    ): Promise<ProductVariant>[] {
-        const cartObject = JSON.parse(cartProductsJson);
-        return cartObject.map((item) => {
-            return this.updateInventory(
-                item.variant_id,
-                item.reduction_quantity
-            );
-        });
-    }
-
-    private getPostCheckoutUpdatePaymentPromises(
-        payments: Payment[],
-        transactionId: string,
-        payerAddress: string,
-        escrowContractAddress: string
-    ): Promise<Order | Payment>[] {
-        const promises: Promise<Order | Payment>[] = [];
-
-        //update payments with transaction info
-        payments.forEach((p, i) => {
-            promises.push(
-                this.updatePaymentAfterTransaction(p.id, {
-                    transaction_id: transactionId,
-                    payer_address: payerAddress,
-                    escrow_contract_address: escrowContractAddress,
-                })
-            );
-        });
-
-        return promises;
-    }
-
-    private getPostCheckoutUpdateOrderPromises(
-        orders: Order[]
-    ): Promise<Order>[] {
-        return orders.map((o) => {
-            return this.orderRepository_.save({
-                id: o.id,
-                payment_status: PaymentStatus.AWAITING,
-            });
-        });
     }
 
     async completeOrderTemplate(cartId: string) {
@@ -637,6 +476,176 @@ export default class OrderService extends MedusaOrderService {
         }
     }
 
+    private async processBuckydropOrders(
+        cartId: string,
+        orders: Order[]
+    ): Promise<void> {
+        try {
+            for (const order of orders) {
+                const { variants, quantities } =
+                    await this.getBuckyProductVariantsFromOrder(order);
+                if (variants?.length) {
+                    const productList: ICreateBuckyOrderProduct[] = [];
+
+                    for (let n = 0; n < variants.length; n++) {
+                        const prodMetadata: any = JSON.parse(
+                            variants[n].product.bucky_metadata
+                        );
+                        const varMetadata: any = JSON.parse(
+                            variants[n].bucky_metadata
+                        );
+
+                        productList.push({
+                            spuCode: prodMetadata?.detail.spuCode,
+                            skuCode: varMetadata.skuCode,
+                            productCount: quantities[n],
+                            platform: prodMetadata?.detail?.platform,
+                            productPrice:
+                                prodMetadata?.detail?.proPrice?.price ??
+                                prodMetadata?.detail?.price?.price ??
+                                0,
+                            productName: prodMetadata?.detail?.goodsName,
+                        });
+                    }
+
+                    const cart: Cart = await this.cartService_.retrieve(
+                        cartId,
+                        {
+                            relations: ['billing_address.country', 'customer'],
+                        }
+                    );
+
+                    this.logger.debug('cart.email: ' + cart.email);
+
+                    let output = {};
+                    if (BUCKY_ORDER_CREATION_MODE == 'old') {
+                        //TODO: replace this with a BuckyService call, and get rid of buckyClient
+                        output = await this.buckyClient.createOrder({
+                            partnerOrderNo: order.id.replace('_', ''),
+                            //partnerOrderNoName: order.id, //TODO: what go here?
+                            country: cart.billing_address.country.name ?? '', //TODO: what format?
+                            countryCode: cart.billing_address.country.iso_2 ?? '', //TODO: what format?
+                            province: cart.billing_address.province ?? '',
+                            city: cart.billing_address.city ?? '',
+                            detailAddress:
+                                `${cart.billing_address.address_1 ?? ''} ${cart.billing_address.address_2 ?? ''}`.trim(),
+                            postCode: cart.billing_address.postal_code,
+                            contactName:
+                                `${cart.billing_address.first_name ?? ''} ${cart.billing_address.last_name ?? ''}`.trim(),
+                            contactPhone: cart.billing_address.phone?.length
+                                ? cart.billing_address.phone
+                                : '0809997747',
+                            email: cart.email?.length
+                                ? cart.email
+                                : cart.customer.email,
+                            orderRemark: '',
+                            productList,
+                        });
+                    }
+                    else {
+                        output = { status: 'pending' };
+                    }
+
+                    //TODO: if not success, need to take some action
+                    order.bucky_metadata = JSON.stringify(output);
+                    await this.orderRepository_.save(order);
+
+                    this.logger.debug('BUCKY CREATED ORDER');
+                    this.logger.debug(JSON.stringify(output));
+                }
+            }
+        } catch (e) {
+            this.logger.error(`Failed to create buckydrop order for ${cartId}`);
+        }
+    }
+
+    private async getCustomerOrdersByStatus(
+        customerId: string,
+        statusParams: {
+            orderStatus?: OrderStatus;
+            paymentStatus?: PaymentStatus;
+            fulfillmentStatus?: FulfillmentStatus;
+        }
+    ): Promise<Order[]> {
+        const where: {
+            customer_id: string;
+            status?: any;
+            payment_status?: any;
+            fulfillment_status?: any;
+        } = {
+            customer_id: customerId,
+            status: Not(OrderStatus.ARCHIVED),
+        };
+
+        if (statusParams.orderStatus) {
+            where.status = statusParams.orderStatus;
+        }
+
+        if (statusParams.paymentStatus) {
+            where.payment_status = statusParams.paymentStatus;
+        }
+
+        if (statusParams.fulfillmentStatus) {
+            where.fulfillment_status = statusParams.fulfillmentStatus;
+        }
+
+        return await this.orderRepository_.find({
+            where,
+            relations: [
+                'items',
+                'store',
+                'shipping_address',
+                'customer',
+                'items.variant.product',
+            ],
+        });
+    }
+
+    private getPostCheckoutUpdateInventoryPromises(
+        cartProductsJson: string
+    ): Promise<ProductVariant>[] {
+        const cartObject = JSON.parse(cartProductsJson);
+        return cartObject.map((item) => {
+            return this.updateInventory(
+                item.variant_id,
+                item.reduction_quantity
+            );
+        });
+    }
+
+    private getPostCheckoutUpdatePaymentPromises(
+        payments: Payment[],
+        transactionId: string,
+        payerAddress: string,
+        escrowContractAddress: string
+    ): Promise<Order | Payment>[] {
+        const promises: Promise<Order | Payment>[] = [];
+
+        //update payments with transaction info
+        payments.forEach((p, i) => {
+            promises.push(
+                this.updatePaymentAfterTransaction(p.id, {
+                    transaction_id: transactionId,
+                    payer_address: payerAddress,
+                    escrow_contract_address: escrowContractAddress,
+                })
+            );
+        });
+
+        return promises;
+    }
+
+    private getPostCheckoutUpdateOrderPromises(
+        orders: Order[]
+    ): Promise<Order>[] {
+        return orders.map((o) => {
+            return this.orderRepository_.save({
+                id: o.id,
+                payment_status: PaymentStatus.AWAITING,
+            });
+        });
+    }
+
     private async getOrdersWithItems(orders: Order[]): Promise<Order[]> {
         let output: Order[] = [];
         for (const order of orders) {
@@ -662,9 +671,9 @@ export default class OrderService extends MedusaOrderService {
 
         return relevantItems?.length
             ? {
-                  products: relevantItems.map((i) => i.variant.product),
-                  quantities: relevantItems.map((i) => i.quantity),
-              }
+                products: relevantItems.map((i) => i.variant.product),
+                quantities: relevantItems.map((i) => i.quantity),
+            }
             : { products: [], quantities: [] };
     }
 
@@ -678,9 +687,9 @@ export default class OrderService extends MedusaOrderService {
 
         return relevantItems?.length
             ? {
-                  variants: relevantItems.map((i) => i.variant),
-                  quantities: relevantItems.map((i) => i.quantity),
-              }
+                variants: relevantItems.map((i) => i.variant),
+                quantities: relevantItems.map((i) => i.quantity),
+            }
             : { variants: [], quantities: [] };
     }
 }

--- a/hamza-server/src/services/product.ts
+++ b/hamza-server/src/services/product.ts
@@ -18,8 +18,6 @@ import PriceSelectionStrategy, {
 } from '../strategies/price-selection';
 import CustomerService from '../services/customer';
 import { ProductVariantRepository } from '../repositories/product-variant';
-import { BuckyClient } from '../buckydrop/bucky-client';
-import { getCurrencyAddress } from '../currency.config';
 import { In, IsNull, Not } from 'typeorm';
 import { createLogger, ILogger } from '../utils/logging/logger';
 
@@ -442,7 +440,9 @@ class ProductService extends MedusaProductService {
         }
     }
 
-    async findByBuckyMetadata(buckyMetadata: string): Promise<Product | null> {
+    /*
+    //TODO: these seem to not be used; kill them?
+    async findByBuckyMetadata(buckyMetadata: Record<string, unknown>): Promise<Product | null> {
         try {
             const product = await this.productRepository_.findOne({
                 where: { bucky_metadata: buckyMetadata },
@@ -489,6 +489,7 @@ class ProductService extends MedusaProductService {
             );
         }
     }
+    */
 
     private async convertPrices(
         products: Product[],

--- a/http-client/local-dev.http
+++ b/http-client/local-dev.http
@@ -359,3 +359,14 @@ Content-Type: application/json
 }
 
 
+#### GET Buckydrop pending orders
+GET http://localhost:9000/custom/bucky/orders
+
+
+### Process a Buckydrop pending order 
+PUT http://localhost:9000/custom/bucky/orders
+Content-Type: application/json
+
+{ "order": "order_01J6P8JMKWCA90DR96TXHFFNC0" }
+
+

--- a/http-client/local-dev.http
+++ b/http-client/local-dev.http
@@ -367,6 +367,5 @@ GET http://localhost:9000/custom/bucky/orders
 PUT http://localhost:9000/custom/bucky/orders
 Content-Type: application/json
 
-{ "order": "order_01J6P8JMKWCA90DR96TXHFFNC0" }
 
 


### PR DESCRIPTION
- Orders for bucky are no longer created automatically at checked, but just marked as 'pending' 
- A new route exists to pull pending bucky orders
- A new route exists to process pending bucky orders (separately from checkout) 
- Later this can be automated thusly: after an automated async process verifies orders on chain, bucky drop orders can be automatically processed 
- Changed all bucky_metadata columns (product, variant, and order) to jsonb (from string)