### PR TITLE
fixed bugs causing cancelOrderFromCart to not succeed when it should

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -376,8 +376,10 @@ export async function removeNotifications(customer_id: string) {
 export async function cancelOrderCart(cart_id: string) {
     try {
         const response = await axios.post(`${BACKEND_URL}/custom/cart/cancel`, {
-            data: {
-                cart_id,
+            cart_id,
+        }, {
+            headers: {
+                authorization: cookies().get('_medusa_jwt')?.value,
             },
         });
         return response;

--- a/hamza-server/src/api/custom/cart/cancel/route.ts
+++ b/hamza-server/src/api/custom/cart/cancel/route.ts
@@ -23,11 +23,11 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         if (!cart)
             return res.status(404).json({ message: `Cart ${cartId} not found` });
 
-
         //enforce security
-        await orderService.cancelOrderFromCart(cartId);
         if (!handler.enforceCustomerId(cart.customer_id))
             return;
+
+        await orderService.cancelOrderFromCart(cartId);
 
         handler.logger.debug(`cancelled ${cartId}`);
         return res.send({ status: true });


### PR DESCRIPTION
Fixed bug: cancelOrderFromCart on client side not succeeding
- some issues on server side 
- headers not passed from client side
- parameter passed incorrectly on client side 
- moved call back to client side to avoid stackoverflow