### PR TITLE
Product image gallery - fixed dimensions on desktop and carousel

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/image-gallery/gallery-modal/index.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/image-gallery/gallery-modal/index.tsx
@@ -135,7 +135,6 @@ const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
                             justifyContent="center"
                             justifyItems="center"
                             gap={{ base: 3, md: 7 }} // Adjust gap for mobile and larger screens
-                            mt={{ base: 0, md: 4 }}
                             width="100%"
                             maxWidth="840px"
                         >
@@ -153,6 +152,7 @@ const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
                                     aspectRatio={'1 / 1'}
                                     width="100%"
                                     maxW={'145px'}
+                                    maxH={'138px'}
                                     onClick={() => {
                                         setSelectedImage(image);
                                         setCurrentIndex(index);
@@ -173,8 +173,7 @@ const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
                         <Flex
                             justifyContent="center"
                             position="absolute"
-                            bottom={{ base: '-17px', md: '-5px' }}
-                            mt={2}
+                            bottom={{ base: '-17px', md: '-17px' }}
                         >
                             {images.map((_, index) => (
                                 <Box key={index} mx={1.5}>

--- a/hamza-client/src/modules/products/components/product-preview/components/image-gallery/gallery-modal/index.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/image-gallery/gallery-modal/index.tsx
@@ -73,7 +73,7 @@ const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
                     >
                         <Box
                             mb={4}
-                            maxH={'598px'}
+                            maxH={'592px'}
                             minH={'242px'}
                             maxWidth="840px"
                             width={'100%'}

--- a/hamza-client/src/modules/products/components/product-preview/components/preview-gallery.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/preview-gallery.tsx
@@ -53,6 +53,8 @@ const PreviewGallery = () => {
                 <GridItem>
                     <Box
                         minWidth={'300px'}
+                        maxH={'600px'}
+                        maxW={'600px'}
                         width={'100%'}
                         aspectRatio="1 / 1"
                         overflow="hidden"


### PR DESCRIPTION
 - fixed dimensions on desktop and carousel
The dimensions were off. The way they designed it was for a smaller width than the rest of the content. I reached out to UX to see if this was their intention but this is more accurate now. I also fixed the gallery modal for lower screen sizes.