### PR TITLE
fixed bug, manifests when user not logged in at checkout

### DIFF
--- a/hamza-client/src/lib/util/get-product-price.ts
+++ b/hamza-client/src/lib/util/get-product-price.ts
@@ -113,7 +113,6 @@ export function formatCryptoPrice(
             : parseFloat(Number(amount).toFixed(displayPrecision));
 
         output = displayPrecision <= 2 ? output : limitPrecision(parseFloat(output.toString()), getCurrencyPrecision(currencyCode).display);
-        console.log('after limiting precision: ', output);
 
         return output;
     } catch (e) {

--- a/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
@@ -42,7 +42,7 @@ const ShippingAddress = ({
     // check if customer has saved addresses that are in the current region
     const addressesInRegion = useMemo(
         () =>
-            customer?.shipping_addresses.filter(
+            customer?.shipping_addresses?.filter(
                 (a) =>
                     a.country_code &&
                     countriesInRegion?.includes(a.country_code)


### PR DESCRIPTION
Fixed bug: 
- when at checkout, and not logged in, customer has no shipping addresses. Therefore the client-side query for customer.shipping_addresses fails. Just added conditional dot. (?.) 