### PR TITLE
shop not store

### DIFF
--- a/hamza-client/src/modules/cart/templates/items.tsx
+++ b/hamza-client/src/modules/cart/templates/items.tsx
@@ -113,7 +113,7 @@ const ItemsTemplate = ({ items, region, currencyCode }: ItemsTemplateProps) => {
                                 </Text>
                             </Flex>
                             <Link
-                                href={'/store'}
+                                href={'/shop'}
                                 textAlign={'center'}
                                 width={'100%'}
                             >


### PR DESCRIPTION
Fixed bug: "continue shopping" button on empty cart should direct to /shop, not /store