### PR TITLE
Payment verify

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -442,7 +442,8 @@ export async function finalizeCheckout(
     cart_id: string,
     transaction_id: string,
     payer_address: string,
-    escrow_contract_address: string
+    escrow_contract_address: string,
+    chain_id: number
     //cart_products: any
 ) {
     return await postSecure('/custom/checkout', {
@@ -451,6 +452,7 @@ export async function finalizeCheckout(
         transaction_id,
         payer_address,
         escrow_contract_address,
+        chain_id
     });
 }
 

--- a/hamza-client/src/modules/checkout/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment-button/index.tsx
@@ -174,12 +174,14 @@ const CryptoPaymentButton = ({
             }
 
             //get the handler to return value
-            return await handler.doWalletPayment(
+            const output = await handler.doWalletPayment(
                 provider,
                 signer,
                 chainId,
                 data
             );
+
+            return output;
         } catch (e) {
             console.error('error has occured during transaction', e);
             displayError('Checkout was not completed.');
@@ -229,7 +231,8 @@ const CryptoPaymentButton = ({
                     cartId,
                     output.transaction_id,
                     output.payer_address,
-                    output.escrow_contract_address
+                    output.escrow_contract_address,
+                    output.chain_id
                     //cartRef.current
                 );
 

--- a/hamza-client/src/modules/checkout/components/payment-button/payment-handlers.ts
+++ b/hamza-client/src/modules/checkout/components/payment-button/payment-handlers.ts
@@ -19,6 +19,7 @@ export type WalletPaymentResponse = {
     payer_address: string;
     escrow_contract_address: string;
     message?: string;
+    chain_id: number;
     success: boolean;
 };
 
@@ -116,6 +117,7 @@ export class MassmarketWalletPaymentHandler implements IWalletPaymentHandler {
             transaction_id,
             payer_address,
             escrow_contract_address,
+            chain_id: chainId,
             success:
                 transaction_id && transaction_id.length ? true : false,
         };
@@ -197,6 +199,7 @@ export class FakeWalletPaymentHandler implements IWalletPaymentHandler {
             escrow_contract_address: '0x0',
             transaction_id,
             payer_address,
+            chain_id: chainId,
             success:
                 transaction_id && transaction_id.length ? true : false,
         }
@@ -237,6 +240,7 @@ export class LiteSwitchWalletPaymentHandler implements IWalletPaymentHandler {
             escrow_contract_address: contractAddress,
             payer_address,
             transaction_id,
+            chain_id: chainId,
             success:
                 transaction_id && transaction_id.length ? true : false,
         };
@@ -293,7 +297,8 @@ export class SwitchWalletPaymentHandler implements IWalletPaymentHandler {
             escrow_contract_address: '',
             payer_address: '',
             transaction_id: '',
-            success: false
+            success: false,
+            chain_id: chainId,
         };
     }
 }
@@ -334,6 +339,7 @@ export class DirectWalletPaymentHandler implements IWalletPaymentHandler {
                         transaction_id,
                         payer_address,
                         success: false,
+                        chain_id: chainId,
                         message: 'Insufficient balance'
                     }
                 }
@@ -377,6 +383,7 @@ export class DirectWalletPaymentHandler implements IWalletPaymentHandler {
             escrow_contract_address: '0x0',
             transaction_id,
             payer_address,
+            chain_id: chainId,
             success:
                 transaction_id && transaction_id.length ? true : false,
         }

--- a/hamza-server/src/api/admin/custom/payments/verify/route.ts
+++ b/hamza-server/src/api/admin/custom/payments/verify/route.ts
@@ -1,0 +1,15 @@
+import type { MedusaRequest, MedusaResponse, Logger } from '@medusajs/medusa';
+import { RouteHandler } from '../../../../route-handler';
+import PaymentVerificationService from '../../../../../services/payment-verification';
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+    const paymentVerificationService: PaymentVerificationService = req.scope.resolve('paymentVerificationService');
+
+    const handler: RouteHandler = new RouteHandler(
+        req, res, 'POST', '/admin/custom/payments/verify', ['products']
+    );
+
+    await handler.handle(async () => {
+        await paymentVerificationService.verifyPayments();
+    });
+};

--- a/hamza-server/src/api/admin/custom/payments/verify/route.ts
+++ b/hamza-server/src/api/admin/custom/payments/verify/route.ts
@@ -3,7 +3,7 @@ import { RouteHandler } from '../../../../route-handler';
 import { Order } from '../../../../../models/order';
 import { Payment } from '../../../../../models/payment';
 import PaymentVerificationService from '../../../../../services/payment-verification';
-import BuckydropService from 'src/services/buckydrop';
+import BuckydropService from '../../../../../services/buckydrop';
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     const paymentVerificationService: PaymentVerificationService = req.scope.resolve('paymentVerificationService');

--- a/hamza-server/src/api/admin/custom/payments/verify/route.ts
+++ b/hamza-server/src/api/admin/custom/payments/verify/route.ts
@@ -1,4 +1,4 @@
-import type { MedusaRequest, MedusaResponse, Logger } from '@medusajs/medusa';
+import type { MedusaRequest, MedusaResponse, Logger, Payment } from '@medusajs/medusa';
 import { RouteHandler } from '../../../../route-handler';
 import PaymentVerificationService from '../../../../../services/payment-verification';
 
@@ -10,10 +10,24 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     );
 
     await handler.handle(async () => {
+        let payments: Payment[];
         if (handler.hasParam('order_id'))
-            await paymentVerificationService.verifyPayments(handler.inputParams.order_id);
+            payments = await paymentVerificationService.verifyPayments(handler.inputParams.order_id);
         else
-            await paymentVerificationService.verifyPayments();
-        return res.json({ ok: 'ok' })
+            payments = await paymentVerificationService.verifyPayments();
+
+        return handler.returnStatus(200, {
+            verified: payments.map(p => {
+                return {
+                    id: p.id,
+                    order_id:
+                        p.order_id,
+                    amount:
+                        p.amount,
+                    currency:
+                        p.currency_code
+                }
+            })
+        });
     });
 };

--- a/hamza-server/src/api/admin/custom/payments/verify/route.ts
+++ b/hamza-server/src/api/admin/custom/payments/verify/route.ts
@@ -10,6 +10,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     );
 
     await handler.handle(async () => {
-        await paymentVerificationService.verifyPayments();
+        if (handler.hasParam('order_id'))
+            await paymentVerificationService.verifyPayments(handler.inputParams.order_id);
+        else
+            await paymentVerificationService.verifyPayments();
+        return res.json({ ok: 'ok' })
     });
 };

--- a/hamza-server/src/api/custom/checkout/route.ts
+++ b/hamza-server/src/api/custom/checkout/route.ts
@@ -79,6 +79,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
             'transaction_id',
             'payer_address',
             'escrow_contract_address',
+            'chain_id',
         ]
     );
 
@@ -104,7 +105,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
                 handler.inputParams.cart_id,
                 handler.inputParams.transaction_id,
                 handler.inputParams.payer_address,
-                handler.inputParams.escrow_contract_address
+                handler.inputParams.escrow_contract_address,
+                handler.inputParams.chain_id
             );
             handler.returnStatusWithMessage(
                 200,

--- a/hamza-server/src/api/custom/store/categories/route.ts
+++ b/hamza-server/src/api/custom/store/categories/route.ts
@@ -8,6 +8,7 @@ type ProductSelector = {
     store_id?: string;
 } & MedusaProductSelector;
 
+//TODO: this route doesn't do anything with categories; its name is wrong (if still used)
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     const storeService: StoreService = req.scope.resolve('storeService');
     const productService: ProductService = req.scope.resolve('productService');

--- a/hamza-server/src/api/route-handler.ts
+++ b/hamza-server/src/api/route-handler.ts
@@ -77,7 +77,7 @@ export class RouteHandler {
             );
             const response: any = await fn(this);
         } catch (err: any) {
-            const errorInfo = `ERROR ${JSON.stringify(err)}`;
+            const errorInfo = `ERROR ${JSON.stringify(err)} ${err}`;
             this.returnStatusWithMessage(500, errorInfo);
             if (this.onError) this.onError(err);
         }

--- a/hamza-server/src/contracts.config.ts
+++ b/hamza-server/src/contracts.config.ts
@@ -1,0 +1,86 @@
+interface Currency {
+    contract_address: string;
+    precision: number;
+}
+
+const chainConfig: any = {
+    11155111: {
+        chain_name: 'sepolia',
+        master_switch: {
+            address: '0x74b7284836F753101bD683C3843e95813b381f18',
+        },
+        massmarket_payment: {
+            address: '0x3d9DbbD22E4903274171ED3e94F674Bb52bCF015',
+        },
+        lite_switch: {
+            //address: '0x08EdF664EB5617d7eCf4F1ec74Ee49d9e99Fbd5f'
+            address: '0x1fFc6ba4FcdfC3Ca72a53c2b64db3807B4A5aec8'
+        },
+        dao: {
+            address: '0x8bA35513C3F5ac659907D222e3DaB38b20f8F52A'
+        }
+    },
+    11155420: {
+        chain_name: 'op-sepolia',
+        master_switch: {
+            address: '0x4B36e6130b4931DCc5A64c4bca366790aAA068d1',
+        },
+        massmarket_payment: {
+            address: '0x0',
+        },
+        lite_switch: {
+            address: '0x0'
+        },
+        dao: {
+            address: '0x8bA35513C3F5ac659907D222e3DaB38b20f8F52A'
+        }
+    },
+    1: {
+        chain_name: 'mainnet',
+        master_switch: {
+            address: '',
+        },
+        massmarket_payment: {
+            address: '0x0',
+        },
+        lite_switch: {
+            address: '0x0'
+        },
+        dao: {
+            address: '0x20823791a73f283d20B1cde299E738D5783499d8'
+        }
+    },
+    10: {
+        chain_name: 'optimism',
+        master_switch: {
+            address: '',
+        },
+        massmarket_payment: {
+            address: '0x0',
+        },
+        lite_switch: {
+            //address: '0xa8866FF28D26cdf312e5C902e8BFDbCf663a36ce'
+            address: '0x5b691FFdc872eC40d63fe34f471e3Edb16dAE154'
+        },
+        dao: {
+            address: '0x214bef460Fda073a328aD02371C48E69Bd13442B'
+        }
+    },
+};
+
+const getContractAddress = (contractId: string, chainId: number = 1) =>
+    chainConfig[chainId]
+        ? chainConfig[chainId][contractId]?.address ?? ''
+        : '';
+
+const getMasterSwitchAddress = (chainId: number = 1) =>
+    chainConfig[chainId]
+        ? chainConfig[chainId]?.master_switch?.address
+        : undefined;
+
+const getMassmarketPaymentAddress = (chainId: number = 1) =>
+    chainConfig[chainId]
+        ? chainConfig[chainId]?.massmarket_payment?.address
+        : undefined;
+
+export { getContractAddress, getMasterSwitchAddress, getMassmarketPaymentAddress };

--- a/hamza-server/src/migrations/9204848284827-Payment.ts
+++ b/hamza-server/src/migrations/9204848284827-Payment.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class BuckyProduct5828595666725 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "payment" ADD "chain_id" bigint`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "payment" DROP COLUMN "chain_id"`
+        );
+    }
+}

--- a/hamza-server/src/migrations/9204848284827-Payment.ts
+++ b/hamza-server/src/migrations/9204848284827-Payment.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner, Table } from 'typeorm';
 
-export class BuckyProduct5828595666725 implements MigrationInterface {
+export class BuckyPayment9204848284827 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
             `ALTER TABLE "payment" ADD "chain_id" bigint`,

--- a/hamza-server/src/models/payment.ts
+++ b/hamza-server/src/models/payment.ts
@@ -14,4 +14,7 @@ export class Payment extends MedusaPayment {
 
     @Column()
     escrow_contract_address?: string;
+
+    @Column()
+    chain_id?: number;
 }

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -190,8 +190,9 @@ export default class OrderService extends MedusaOrderService {
     async finalizeCheckout(
         cartId: string,
         transactionId: string,
-        payerAddress,
-        escrowContractAddress
+        payerAddress: string,
+        escrowContractAddress: string,
+        chainId: number
     ): Promise<Order[]> {
         //get orders & order ids
         const orders: Order[] = await this.orderRepository_.find({
@@ -217,7 +218,8 @@ export default class OrderService extends MedusaOrderService {
             payments,
             transactionId,
             payerAddress,
-            escrowContractAddress
+            escrowContractAddress,
+            chainId
         );
 
         //calls to update orders
@@ -596,7 +598,8 @@ export default class OrderService extends MedusaOrderService {
         payments: Payment[],
         transactionId: string,
         payerAddress: string,
-        escrowContractAddress: string
+        escrowContractAddress: string,
+        chainId: number
     ): Promise<Order | Payment>[] {
         const promises: Promise<Order | Payment>[] = [];
 
@@ -607,6 +610,7 @@ export default class OrderService extends MedusaOrderService {
                     transaction_id: transactionId,
                     payer_address: payerAddress,
                     escrow_contract_address: escrowContractAddress,
+                    chain_id: chainId
                 })
             );
         });

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -16,16 +16,13 @@ import { ProductVariantRepository } from '../repositories/product-variant';
 import StoreRepository from '../repositories/store';
 import { LineItemService } from '@medusajs/medusa';
 import { Order } from '../models/order';
-import { Product } from '../models/product';
 import { Payment } from '../models/payment';
 import { Lifetime } from 'awilix';
 import { In, Not } from 'typeorm';
 import {
-    BuckyClient,
-    ICreateBuckyOrderProduct,
+    BuckyClient
 } from '../buckydrop/bucky-client';
 import ProductRepository from '@medusajs/medusa/dist/repositories/product';
-import BuckydropService from './buckydrop';
 import { createLogger, ILogger } from '../utils/logging/logger';
 
 // Since {TO_PAY, TO_SHIP} are under the umbrella name {Processing} in FE, not sure if we should modify atm
@@ -508,10 +505,17 @@ export default class OrderService extends MedusaOrderService {
 
         return relevantItems?.length
             ? {
-                  variants: relevantItems.map((i) => i.variant),
-                  quantities: relevantItems.map((i) => i.quantity),
-              }
+                variants: relevantItems.map((i) => i.variant),
+                quantities: relevantItems.map((i) => i.quantity),
+            }
             : { variants: [], quantities: [] };
+    }
+
+    async getOrdersWithUnverifiedPayments() {
+        return await this.orderRepository_.find({
+            where: { payment_status: PaymentStatus.AWAITING },
+            relations: ['payments']
+        });
     }
 
     private async processBuckydropOrders(

--- a/hamza-server/src/services/payment-verification.ts
+++ b/hamza-server/src/services/payment-verification.ts
@@ -1,0 +1,51 @@
+import { Lifetime } from 'awilix';
+import {
+    PaymentStatus,
+    TransactionBaseService,
+} from '@medusajs/medusa';
+import { createLogger, ILogger } from '../utils/logging/logger';
+import OrderService from './order';
+import { Payment } from '../models/payment';
+import { Order } from '../models/order';
+import PaymentRepository from '@medusajs/medusa/dist/repositories/payment';
+import OrderRepository from '@medusajs/medusa/dist/repositories/order';
+import { verifyPaymentForOrder } from 'src/web3';
+
+export default class PaymentVerificationService extends TransactionBaseService {
+    static LIFE_TIME = Lifetime.SCOPED;
+    protected readonly paymentRepository_: typeof PaymentRepository;
+    protected readonly orderRepository_: typeof OrderRepository;
+    protected readonly orderService_: OrderService;
+    protected readonly logger: ILogger;
+
+    constructor(container) {
+        super(container);
+        this.paymentRepository_ = container.paymentRepository;
+        this.orderService_ = container.orderService;
+        this.logger = createLogger(container, 'PaymentVerificationService');
+    }
+
+    async verifyPayments(): Promise<void> {
+        //const payments = await this.getPaymentsToVerify();
+        const orders = await this.orderService_.getOrdersWithUnverifiedPayments();
+
+        for (let order of orders) {
+            await this.verifyPayment(order);
+        }
+    }
+
+    private async verifyPayment(order: Order): Promise<void> {
+        let allPaid: boolean = true;
+        for (let payment of order.payments) {
+            if (!await verifyPaymentForOrder(order.id, payment.amount)) {
+                allPaid = false;
+                break;
+            }
+        }
+
+        if (allPaid) {
+            order.payment_status = PaymentStatus.CAPTURED;
+            await this.orderRepository_.save(order);
+        }
+    }
+}

--- a/hamza-server/src/services/payment-verification.ts
+++ b/hamza-server/src/services/payment-verification.ts
@@ -23,8 +23,8 @@ export default class PaymentVerificationService extends TransactionBaseService {
         this.logger = createLogger(container, 'PaymentVerificationService');
     }
 
-    async verifyPayments(order_id: string = null): Promise<Payment[]> {
-        let output: Payment[] = [];
+    async verifyPayments(order_id: string = null): Promise<{ order: Order, payment: Payment }[]> {
+        let output: { order: Order, payment: Payment }[] = [];
         let orders = await this.orderService_.getOrdersWithUnverifiedPayments();
 
         if (order_id)
@@ -38,8 +38,8 @@ export default class PaymentVerificationService extends TransactionBaseService {
         return output;
     }
 
-    private async verifyPayment(order: Order): Promise<Payment[]> {
-        let output: Payment[] = [];
+    private async verifyPayment(order: Order): Promise<{ order: Order, payment: Payment }[]> {
+        let output: { order: Order, payment: Payment }[] = [];
         let allPaid: boolean = true;
         const payments: Payment[] = order.payments;
 
@@ -58,7 +58,10 @@ export default class PaymentVerificationService extends TransactionBaseService {
             this.logger.info(`updating order ${order.id}, setting to captured`);
             order.payment_status = PaymentStatus.CAPTURED;
             await this.orderRepository_.save(order);
-            output = output.concat(order.payments);
+
+            for (let p of order.payments) {
+                output.push({ order: order, payment: p });
+            }
         }
 
         return output;

--- a/hamza-server/src/services/payment-verification.ts
+++ b/hamza-server/src/services/payment-verification.ts
@@ -13,22 +13,24 @@ import { verifyPaymentForOrder } from '../web3';
 
 export default class PaymentVerificationService extends TransactionBaseService {
     static LIFE_TIME = Lifetime.SCOPED;
-    protected readonly paymentRepository_: typeof PaymentRepository;
     protected readonly orderRepository_: typeof OrderRepository;
     protected readonly orderService_: OrderService;
     protected readonly logger: ILogger;
 
     constructor(container) {
         super(container);
-        this.paymentRepository_ = container.paymentRepository;
+        this.orderRepository_ = container.orderRepository;
         this.orderService_ = container.orderService;
         this.logger = createLogger(container, 'PaymentVerificationService');
     }
 
-    async verifyPayments(): Promise<void> {
+    async verifyPayments(order_id: string = null): Promise<void> {
         //const payments = await this.getPaymentsToVerify();
-        const orders = await this.orderService_.getOrdersWithUnverifiedPayments();
+        let orders = await this.orderService_.getOrdersWithUnverifiedPayments();
         console.log('orders:', orders.length);
+
+        if (order_id)
+            orders = orders.filter(o => o.id == order_id);
 
         for (let order of orders) {
             console.log('verifying payment for ', order.id);

--- a/hamza-server/src/services/payment-verification.ts
+++ b/hamza-server/src/services/payment-verification.ts
@@ -7,7 +7,6 @@ import { createLogger, ILogger } from '../utils/logging/logger';
 import OrderService from './order';
 import { Payment } from '../models/payment';
 import { Order } from '../models/order';
-import PaymentRepository from '@medusajs/medusa/dist/repositories/payment';
 import OrderRepository from '@medusajs/medusa/dist/repositories/order';
 import { verifyPaymentForOrder } from '../web3';
 
@@ -24,34 +23,44 @@ export default class PaymentVerificationService extends TransactionBaseService {
         this.logger = createLogger(container, 'PaymentVerificationService');
     }
 
-    async verifyPayments(order_id: string = null): Promise<void> {
-        //const payments = await this.getPaymentsToVerify();
+    async verifyPayments(order_id: string = null): Promise<Payment[]> {
+        let output: Payment[] = [];
         let orders = await this.orderService_.getOrdersWithUnverifiedPayments();
-        console.log('orders:', orders.length);
 
         if (order_id)
             orders = orders.filter(o => o.id == order_id);
 
         for (let order of orders) {
-            console.log('verifying payment for ', order.id);
-            await this.verifyPayment(order);
+            this.logger.info(`verifying payment for ${order.id}`);
+            output = output.concat(await this.verifyPayment(order));
         }
+
+        return output;
     }
 
-    private async verifyPayment(order: Order): Promise<void> {
+    private async verifyPayment(order: Order): Promise<Payment[]> {
+        let output: Payment[] = [];
         let allPaid: boolean = true;
-        for (let payment of order.payments) {
-            //TODO: get chain from order or payment
-            if (!await verifyPaymentForOrder(11155111, order.id, payment.amount)) {
+        const payments: Payment[] = order.payments;
+
+        //verify each payment of order
+        for (let payment of payments) {
+            this.logger.info(`verifying payment ${payment.id} for order ${order.id}`);
+
+            if (!await verifyPaymentForOrder(payment.chain_id, order.id, payment.amount)) {
+                //if any unverifiable, then the whole order is unverifiable
                 allPaid = false;
                 break;
             }
         }
 
         if (allPaid) {
-            console.log('updating order ', order.id);
+            this.logger.info(`updating order ${order.id}, setting to captured`);
             order.payment_status = PaymentStatus.CAPTURED;
             await this.orderRepository_.save(order);
+            output = output.concat(order.payments);
         }
+
+        return output;
     }
 }

--- a/hamza-server/src/web3/abi/erc20-abi.ts
+++ b/hamza-server/src/web3/abi/erc20-abi.ts
@@ -1,0 +1,222 @@
+export const erc20abi = [
+    {
+        constant: true,
+        inputs: [],
+        name: 'name',
+        outputs: [
+            {
+                name: '',
+                type: 'string',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_spender',
+                type: 'address',
+            },
+            {
+                name: '_value',
+                type: 'uint256',
+            },
+        ],
+        name: 'approve',
+        outputs: [
+            {
+                name: '',
+                type: 'bool',
+            },
+        ],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'totalSupply',
+        outputs: [
+            {
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_from',
+                type: 'address',
+            },
+            {
+                name: '_to',
+                type: 'address',
+            },
+            {
+                name: '_value',
+                type: 'uint256',
+            },
+        ],
+        name: 'transferFrom',
+        outputs: [
+            {
+                name: '',
+                type: 'bool',
+            },
+        ],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'decimals',
+        outputs: [
+            {
+                name: '',
+                type: 'uint8',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [
+            {
+                name: '_owner',
+                type: 'address',
+            },
+        ],
+        name: 'balanceOf',
+        outputs: [
+            {
+                name: 'balance',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'symbol',
+        outputs: [
+            {
+                name: '',
+                type: 'string',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_to',
+                type: 'address',
+            },
+            {
+                name: '_value',
+                type: 'uint256',
+            },
+        ],
+        name: 'transfer',
+        outputs: [
+            {
+                name: '',
+                type: 'bool',
+            },
+        ],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [
+            {
+                name: '_owner',
+                type: 'address',
+            },
+            {
+                name: '_spender',
+                type: 'address',
+            },
+        ],
+        name: 'allowance',
+        outputs: [
+            {
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        payable: true,
+        stateMutability: 'payable',
+        type: 'fallback',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                name: 'owner',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                name: 'spender',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                name: 'value',
+                type: 'uint256',
+            },
+        ],
+        name: 'Approval',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                name: 'from',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                name: 'to',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                name: 'value',
+                type: 'uint256',
+            },
+        ],
+        name: 'Transfer',
+        type: 'event',
+    },
+];

--- a/hamza-server/src/web3/abi/lite-switch-abi.ts
+++ b/hamza-server/src/web3/abi/lite-switch-abi.ts
@@ -1,0 +1,409 @@
+export const liteSwitchAbi = [
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "securityContext",
+                "type": "address",
+                "internalType": "contract ISecurityContext"
+            },
+            {
+                "name": "vault",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "receive",
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "ADMIN_ROLE",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "APPROVER_ROLE",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "DAO_ROLE",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "PAUSER_ROLE",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "REFUNDER_ROLE",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "SYSTEM_ROLE",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "UPGRADER_ROLE",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "placeMultiPayments",
+        "inputs": [
+            {
+                "name": "multiPayments",
+                "type": "tuple[]",
+                "internalType": "struct MultiPaymentInput[]",
+                "components": [
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "payments",
+                        "type": "tuple[]",
+                        "internalType": "struct PaymentInput[]",
+                        "components": [
+                            {
+                                "name": "id",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            },
+                            {
+                                "name": "orderId",
+                                "type": "string",
+                                "internalType": "string"
+                            },
+                            {
+                                "name": "receiver",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "payer",
+                                "type": "address",
+                                "internalType": "address"
+                            },
+                            {
+                                "name": "amount",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "immediateSweep",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "outputs": [
+
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "securityContext",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract ISecurityContext"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "setSecurityContext",
+        "inputs": [
+            {
+                "name": "_securityContext",
+                "type": "address",
+                "internalType": "contract ISecurityContext"
+            }
+        ],
+        "outputs": [
+
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "setVaultAddress",
+        "inputs": [
+            {
+                "name": "_vaultAddress",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "sweep",
+        "inputs": [
+            {
+                "name": "tokenAddressOrZero",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "vaultAddress",
+        "inputs": [
+
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "event",
+        "name": "PaymentReceived",
+        "inputs": [
+            {
+                "name": "orderId",
+                "type": "string",
+                "indexed": true,
+                "internalType": "string"
+            },
+            {
+                "name": "to",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "from",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "currency",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "PaymentSweepFailed",
+        "inputs": [
+            {
+                "name": "from",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "currency",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "PaymentSwept",
+        "inputs": [
+            {
+                "name": "from",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "currency",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "SecurityContextSet",
+        "inputs": [
+            {
+                "name": "caller",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "securityContext",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "VaultAddressChanged",
+        "inputs": [
+            {
+                "name": "newAddress",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "changedBy",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "UnauthorizedAccess",
+        "inputs": [
+            {
+                "name": "roleId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "addr",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ZeroAddressArgument",
+        "inputs": [
+
+        ]
+    }
+];

--- a/hamza-server/src/web3/abi/massmarket-payment-abi.ts
+++ b/hamza-server/src/web3/abi/massmarket-payment-abi.ts
@@ -1,0 +1,578 @@
+export const massMarketPaymentAbi = [
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "_permit2",
+                "type": "address",
+                "internalType": "contract IPermit2"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "getPaymentId",
+        "inputs": [
+            {
+                "name": "payment",
+                "type": "tuple",
+                "internalType": "struct PaymentRequest",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "hasPaymentBeenMade",
+        "inputs": [
+            {
+                "name": "from",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "payment",
+                "type": "tuple",
+                "internalType": "struct PaymentRequest",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "multiPay",
+        "inputs": [
+            {
+                "name": "payments",
+                "type": "tuple[]",
+                "internalType": "struct PaymentRequest[]",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            },
+            {
+                "name": "permit2Sigs",
+                "type": "bytes[]",
+                "internalType": "bytes[]"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "pay",
+        "inputs": [
+            {
+                "name": "payment",
+                "type": "tuple",
+                "internalType": "struct PaymentRequest",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "payNative",
+        "inputs": [
+            {
+                "name": "payment",
+                "type": "tuple",
+                "internalType": "struct PaymentRequest",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "payToken",
+        "inputs": [
+            {
+                "name": "payment",
+                "type": "tuple",
+                "internalType": "struct PaymentRequest",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            },
+            {
+                "name": "permit2signature",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "payTokenPreApproved",
+        "inputs": [
+            {
+                "name": "payment",
+                "type": "tuple",
+                "internalType": "struct PaymentRequest",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "revertPayment",
+        "inputs": [
+            {
+                "name": "from",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "payment",
+                "type": "tuple",
+                "internalType": "struct PaymentRequest",
+                "components": [
+                    {
+                        "name": "chainId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "order",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "currency",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "payeeAddress",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "isPaymentEndpoint",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "shopId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "shopSignature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "event",
+        "name": "PaymentMade",
+        "inputs": [
+            {
+                "name": "paymentId",
+                "type": "uint256",
+                "indexed": true,
+                "internalType": "uint256"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "InvalidPaymentAmount",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidPaymentToken",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NotPayee",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "PayeeRefusedPayment",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "PaymentAlreadyMade",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "PaymentExpired",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "PaymentNotMade",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "WrongChain",
+        "inputs": []
+    }
+]

--- a/hamza-server/src/web3/abi/switch-abi.ts
+++ b/hamza-server/src/web3/abi/switch-abi.ts
@@ -1,0 +1,1178 @@
+export const switchAbi = [
+    {
+        inputs: [
+            {
+                internalType: 'contract IMasterSwitch',
+                name: 'masterSwitch',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'bucketIndex',
+                type: 'uint256',
+            },
+        ],
+        name: 'InvalidBucketState',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+        ],
+        name: 'InvalidOrderId',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint8',
+                name: 'state',
+                type: 'uint8',
+            },
+        ],
+        name: 'InvalidOrderState',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+        ],
+        name: 'InvalidPaymentOperation',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+            },
+        ],
+        name: 'InvalidRefundAmount',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'x',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256',
+                name: 'y',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256',
+                name: 'denominator',
+                type: 'uint256',
+            },
+        ],
+        name: 'PRBMath__MulDivOverflow',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'amount1',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256',
+                name: 'amount2',
+                type: 'uint256',
+            },
+        ],
+        name: 'PaymentAmountMismatch',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+        ],
+        name: 'PaymentFailed',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'expected',
+                type: 'address',
+            },
+            {
+                internalType: 'address',
+                name: 'actual',
+                type: 'address',
+            },
+        ],
+        name: 'ReceiverMismatch',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'bytes32',
+                name: 'roleId',
+                type: 'bytes32',
+            },
+            {
+                internalType: 'address',
+                name: 'addr',
+                type: 'address',
+            },
+        ],
+        name: 'UnauthorizedAccess',
+        type: 'error',
+    },
+    {
+        inputs: [],
+        name: 'ZeroAddressArgument',
+        type: 'error',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'account',
+                type: 'address',
+            },
+        ],
+        name: 'Paused',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'payer',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+            },
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+        ],
+        name: 'PaymentPlaced',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'refundAmount',
+                type: 'uint256',
+            },
+        ],
+        name: 'PaymentRefunded',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+            },
+            {
+                indexed: false,
+                internalType: 'bool',
+                name: 'success',
+                type: 'bool',
+            },
+        ],
+        name: 'PaymentSent',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'caller',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'securityContext',
+                type: 'address',
+            },
+        ],
+        name: 'SecurityContextSet',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'account',
+                type: 'address',
+            },
+        ],
+        name: 'Unpaused',
+        type: 'event',
+    },
+    {
+        inputs: [],
+        name: 'ADMIN_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'APPROVER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'DAO_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'PAUSER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'REFUNDER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'SYSTEM_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'UPGRADER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+        ],
+        name: 'approvePayments',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address[]',
+                name: 'receivers',
+                type: 'address[]',
+            },
+        ],
+        name: 'approvePaymentsBatch',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+        ],
+        name: 'freezePending',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address[]',
+                name: 'receivers',
+                type: 'address[]',
+            },
+        ],
+        name: 'freezePendingBatch',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+        ],
+        name: 'getAmountToPayOut',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+            {
+                internalType: 'uint8',
+                name: 'state',
+                type: 'uint8',
+            },
+        ],
+        name: 'getBucketCountWithState',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+        ],
+        name: 'getBuckets',
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'uint256',
+                        name: 'total',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint8',
+                        name: 'state',
+                        type: 'uint8',
+                    },
+                    {
+                        components: [
+                            {
+                                internalType: 'uint256',
+                                name: 'id',
+                                type: 'uint256',
+                            },
+                            {
+                                internalType: 'address',
+                                name: 'payer',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'uint256',
+                                name: 'amount',
+                                type: 'uint256',
+                            },
+                            {
+                                internalType: 'uint256',
+                                name: 'refundAmount',
+                                type: 'uint256',
+                            },
+                        ],
+                        internalType: 'struct PaymentBook.Payment[]',
+                        name: 'payments',
+                        type: 'tuple[]',
+                    },
+                ],
+                internalType: 'struct PaymentBook.PaymentBucket[]',
+                name: '',
+                type: 'tuple[]',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+        ],
+        name: 'getPaymentById',
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'uint256',
+                        name: 'id',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'payer',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'amount',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'refundAmount',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint8',
+                        name: 'state',
+                        type: 'uint8',
+                    },
+                ],
+                internalType: 'struct PaymentBook.PaymentWithState',
+                name: '',
+                type: 'tuple',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+            {
+                internalType: 'uint8',
+                name: 'state',
+                type: 'uint8',
+            },
+        ],
+        name: 'getTotalInState',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'masterSwitch',
+        outputs: [
+            {
+                internalType: 'contract IMasterSwitch',
+                name: '',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'pause',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'paused',
+        outputs: [
+            {
+                internalType: 'bool',
+                name: '',
+                type: 'bool',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+        ],
+        name: 'paymentExists',
+        outputs: [
+            {
+                internalType: 'bool',
+                name: '',
+                type: 'bool',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'uint256',
+                        name: 'id',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'receiver',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'payer',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'amount',
+                        type: 'uint256',
+                    },
+                ],
+                internalType: 'struct PaymentInput[]',
+                name: 'payments',
+                type: 'tuple[]',
+            },
+        ],
+        name: 'placeMultiPayments',
+        outputs: [],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'uint256',
+                        name: 'id',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'receiver',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'payer',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'amount',
+                        type: 'uint256',
+                    },
+                ],
+                internalType: 'struct PaymentInput',
+                name: 'payment',
+                type: 'tuple',
+            },
+        ],
+        name: 'placePayment',
+        outputs: [],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+            },
+        ],
+        name: 'placePayment2',
+        outputs: [],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+        ],
+        name: 'processPayments',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address[]',
+                name: 'receivers',
+                type: 'address[]',
+            },
+        ],
+        name: 'processPaymentsBatch',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'pullPayment',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'receiver',
+                type: 'address',
+            },
+        ],
+        name: 'pushPayment',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+            },
+        ],
+        name: 'refundPayment',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'id',
+                type: 'uint256',
+            },
+        ],
+        name: 'reviewPayment',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'securityContext',
+        outputs: [
+            {
+                internalType: 'contract ISecurityContext',
+                name: '',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract ISecurityContext',
+                name: '_securityContext',
+                type: 'address',
+            },
+        ],
+        name: 'setSecurityContext',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'tokenAddress',
+        outputs: [
+            {
+                internalType: 'address',
+                name: '',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'pure',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'unpause',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+];
+
+export const masterAbi = [
+    {
+        inputs: [
+            {
+                internalType: 'contract ISecurityContext',
+                name: 'securityContext',
+                type: 'address',
+            },
+            {
+                internalType: 'address',
+                name: 'vault',
+                type: 'address',
+            },
+            {
+                internalType: 'uint256',
+                name: '_feeBps',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'bytes32',
+                name: 'roleId',
+                type: 'bytes32',
+            },
+            {
+                internalType: 'address',
+                name: 'addr',
+                type: 'address',
+            },
+        ],
+        name: 'UnauthorizedAccess',
+        type: 'error',
+    },
+    {
+        inputs: [],
+        name: 'ZeroAddressArgument',
+        type: 'error',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'newValue',
+                type: 'uint256',
+            },
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'changedBy',
+                type: 'address',
+            },
+        ],
+        name: 'FeeBpsChanged',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'caller',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'securityContext',
+                type: 'address',
+            },
+        ],
+        name: 'SecurityContextSet',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'newAddress',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'changedBy',
+                type: 'address',
+            },
+        ],
+        name: 'VaultAddressChanged',
+        type: 'event',
+    },
+    {
+        inputs: [],
+        name: 'ADMIN_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'APPROVER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'DAO_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'PAUSER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'REFUNDER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'SYSTEM_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'UPGRADER_ROLE',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: '',
+                type: 'bytes32',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'feeBps',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'address',
+                        name: 'receiver',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'currency',
+                        type: 'address',
+                    },
+                    {
+                        components: [
+                            {
+                                internalType: 'uint256',
+                                name: 'id',
+                                type: 'uint256',
+                            },
+                            {
+                                internalType: 'address',
+                                name: 'receiver',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'address',
+                                name: 'payer',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'uint256',
+                                name: 'amount',
+                                type: 'uint256',
+                            },
+                        ],
+                        internalType: 'struct PaymentInput[]',
+                        name: 'payments',
+                        type: 'tuple[]',
+                    },
+                ],
+                internalType: 'struct MultiPaymentInput[]',
+                name: 'multiPayments',
+                type: 'tuple[]',
+            },
+        ],
+        name: 'placeMultiPayments',
+        outputs: [],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'securityContext',
+        outputs: [
+            {
+                internalType: 'contract ISecurityContext',
+                name: '',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: '_feeBps',
+                type: 'uint256',
+            },
+        ],
+        name: 'setFeeBps',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract ISecurityContext',
+                name: '_securityContext',
+                type: 'address',
+            },
+        ],
+        name: 'setSecurityContext',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: '_vaultAddress',
+                type: 'address',
+            },
+        ],
+        name: 'setVaultAddress',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'vaultAddress',
+        outputs: [
+            {
+                internalType: 'address',
+                name: '',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+];

--- a/hamza-server/src/web3/contracts/lite-switch.ts
+++ b/hamza-server/src/web3/contracts/lite-switch.ts
@@ -1,8 +1,13 @@
 import { BigNumberish, ethers } from 'ethers';
 import { liteSwitchAbi } from '../abi/lite-switch-abi';
 import { createPublicClient, http, PublicClient } from 'viem';
-import { sepolia } from 'viem/chains';
+import * as chains from 'viem/chains';
 import { getContractAddress } from '../../contracts.config';
+
+function getChainById(chainId: number) {
+    const allChains = Object.values(chains);
+    return allChains.find(chain => chain.id === chainId) || null;
+}
 
 export class LiteSwitchClient {
     contractAddress: `0x${string}`;
@@ -20,7 +25,7 @@ export class LiteSwitchClient {
         console.log(this.contractAddress);
 
         this.client = createPublicClient({
-            chain: sepolia, //TODO: get from chain id
+            chain: chains[getChainById(chainId).name],
             transport: http(),
         });
     }

--- a/hamza-server/src/web3/contracts/lite-switch.ts
+++ b/hamza-server/src/web3/contracts/lite-switch.ts
@@ -1,0 +1,55 @@
+import { BigNumberish, ethers } from 'ethers';
+import { liteSwitchAbi } from '../abi/lite-switch-abi';
+import { erc20abi } from '../abi/erc20-abi';
+import { createPublicClient, http } from 'viem';
+import { sepolia } from 'viem/chains';
+
+export class LiteSwitchClient {
+    contractAddress: string;
+    switchClient: ethers.Contract;
+    provider: ethers.Provider;
+    signer: ethers.Signer;
+    tokens: { [id: string]: ethers.Contract } = {};
+
+    /**
+     * Constructor.
+     * @param address Address of the LiteSwitch contract
+     */
+    constructor(
+        provider: ethers.Provider,
+        signer: ethers.Signer,
+        address: string
+    ) {
+        this.provider = provider;
+        this.signer = signer;
+        this.contractAddress = address;
+
+        this.switchClient = new ethers.Contract(
+            this.contractAddress,
+            liteSwitchAbi,
+            signer
+        );
+    }
+
+    async findPaymentEvents(orderId: string): Promise<any[]> {
+        return await this.findEvents('PaymentReceived', { orderId });
+    }
+
+    async findEvents(eventName: string, args: any = null): Promise<any[]> {
+
+        // Create a client to interact with Ethereum
+        const client = createPublicClient({
+            chain: sepolia,
+            transport: http(),
+        });
+        // Get the logs from the blockchain
+        const events = await client.getContractEvents({
+            address: '0x1fFc6ba4FcdfC3Ca72a53c2b64db3807B4A5aec8',
+            abi: liteSwitchAbi,
+            eventName: eventName,
+            args,
+        });
+
+        return events;
+    }
+}

--- a/hamza-server/src/web3/contracts/lite-switch.ts
+++ b/hamza-server/src/web3/contracts/lite-switch.ts
@@ -17,6 +17,7 @@ export class LiteSwitchClient {
         chainId: number
     ) {
         this.contractAddress = getContractAddress('lite_switch', chainId);
+        console.log(this.contractAddress);
 
         this.client = createPublicClient({
             chain: sepolia, //TODO: get from chain id
@@ -32,6 +33,7 @@ export class LiteSwitchClient {
         const events = await this.client.getContractEvents({
             address: this.contractAddress,
             abi: liteSwitchAbi,
+            fromBlock: '0x6529B4', //TODO: get actual block starting block (contract creation block)
             eventName: eventName,
             args,
         });

--- a/hamza-server/src/web3/contracts/lite-switch.ts
+++ b/hamza-server/src/web3/contracts/lite-switch.ts
@@ -1,14 +1,12 @@
 import { BigNumberish, ethers } from 'ethers';
 import { liteSwitchAbi } from '../abi/lite-switch-abi';
-import { erc20abi } from '../abi/erc20-abi';
-import { createPublicClient, http } from 'viem';
+import { createPublicClient, http, PublicClient } from 'viem';
 import { sepolia } from 'viem/chains';
+import { getContractAddress } from '../../contracts.config';
 
 export class LiteSwitchClient {
-    contractAddress: string;
-    switchClient: ethers.Contract;
-    provider: ethers.Provider;
-    signer: ethers.Signer;
+    contractAddress: `0x${string}`;
+    client: any;
     tokens: { [id: string]: ethers.Contract } = {};
 
     /**
@@ -16,19 +14,14 @@ export class LiteSwitchClient {
      * @param address Address of the LiteSwitch contract
      */
     constructor(
-        provider: ethers.Provider,
-        signer: ethers.Signer,
-        address: string
+        chainId: number
     ) {
-        this.provider = provider;
-        this.signer = signer;
-        this.contractAddress = address;
+        this.contractAddress = getContractAddress('lite_switch', chainId);
 
-        this.switchClient = new ethers.Contract(
-            this.contractAddress,
-            liteSwitchAbi,
-            signer
-        );
+        this.client = createPublicClient({
+            chain: sepolia, //TODO: get from chain id
+            transport: http(),
+        });
     }
 
     async findPaymentEvents(orderId: string): Promise<any[]> {
@@ -36,15 +29,8 @@ export class LiteSwitchClient {
     }
 
     async findEvents(eventName: string, args: any = null): Promise<any[]> {
-
-        // Create a client to interact with Ethereum
-        const client = createPublicClient({
-            chain: sepolia,
-            transport: http(),
-        });
-        // Get the logs from the blockchain
-        const events = await client.getContractEvents({
-            address: '0x1fFc6ba4FcdfC3Ca72a53c2b64db3807B4A5aec8',
+        const events = await this.client.getContractEvents({
+            address: this.contractAddress,
             abi: liteSwitchAbi,
             eventName: eventName,
             args,

--- a/hamza-server/src/web3/index.ts
+++ b/hamza-server/src/web3/index.ts
@@ -1,0 +1,18 @@
+import { BigNumberish, ethers } from 'ethers';
+import { HexString } from 'ethers/lib.commonjs/utils/data';
+import { createPublicClient, http } from 'viem';
+import { mainnet, optimism, sepolia } from 'viem/chains';
+import { liteSwitchAbi } from './abi/lite-switch-abi';
+import { getContractAddress } from 'src/contracts.config';
+
+
+export async function verifyPaymentForOrder(orderId: string, amount: BigNumberish): Promise<boolean> {
+    const switchClient = new LiteSwitchClient();
+    const events = await switchClient.findPaymentEvents(orderId);
+    let total: BigNumberish = 0;
+    if (events.length) {
+        events.map(e => total += e.amount);
+    }
+
+    return (BigInt(total) >= BigInt(amount));
+}

--- a/hamza-server/src/web3/index.ts
+++ b/hamza-server/src/web3/index.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, ethers } from 'ethers';
+import { BigNumberish } from 'ethers';
 import { LiteSwitchClient } from './contracts/lite-switch';
 
 
@@ -12,6 +12,6 @@ export async function verifyPaymentForOrder(chainId: number, orderId: string, am
         events.map(e => total = total + BigInt(e.args.amount.toString()));
     }
 
-    console.log('total vs. amount: ', total, amount); //TODO: amount must be adjusted 
+    console.log('total vs. amount: ', total, amount); //TODO: amount must be adjusted for currency
     return (BigInt(total) >= BigInt(amount));
 }

--- a/hamza-server/src/web3/index.ts
+++ b/hamza-server/src/web3/index.ts
@@ -1,18 +1,17 @@
 import { BigNumberish, ethers } from 'ethers';
-import { HexString } from 'ethers/lib.commonjs/utils/data';
-import { createPublicClient, http } from 'viem';
-import { mainnet, optimism, sepolia } from 'viem/chains';
-import { liteSwitchAbi } from './abi/lite-switch-abi';
-import { getContractAddress } from 'src/contracts.config';
+import { LiteSwitchClient } from './contracts/lite-switch';
 
 
-export async function verifyPaymentForOrder(orderId: string, amount: BigNumberish): Promise<boolean> {
-    const switchClient = new LiteSwitchClient();
+export async function verifyPaymentForOrder(chainId: number, orderId: string, amount: BigNumberish): Promise<boolean> {
+    const switchClient = new LiteSwitchClient(chainId);
     const events = await switchClient.findPaymentEvents(orderId);
+    console.log('events: ', events);
+
     let total: BigNumberish = 0;
     if (events.length) {
         events.map(e => total += e.amount);
     }
 
+    console.log('total vs. amount: ', total, amount);
     return (BigInt(total) >= BigInt(amount));
 }

--- a/hamza-server/src/web3/index.ts
+++ b/hamza-server/src/web3/index.ts
@@ -7,11 +7,11 @@ export async function verifyPaymentForOrder(chainId: number, orderId: string, am
     const events = await switchClient.findPaymentEvents(orderId);
     console.log('events: ', events);
 
-    let total: BigNumberish = 0;
+    let total: bigint = BigInt(0);
     if (events.length) {
-        events.map(e => total += e.amount);
+        events.map(e => total = total + BigInt(e.args.amount.toString()));
     }
 
-    console.log('total vs. amount: ', total, amount);
+    console.log('total vs. amount: ', total, amount); //TODO: amount must be adjusted 
     return (BigInt(total) >= BigInt(amount));
 }


### PR DESCRIPTION
This is a new way of handling payments, and affects buckydrop. 

Once upon a time, buckydrop products were ordered from buckydrop as soon as checkout was complete. 
Now, they get a 'pending' status in their buckydrop metadata. 
Later, a separate process will sweep the blockchain to verify payments whose status is 'AWAITING', and change the payment status to 'CAPTURED' once the payment has been verified. 
Payments are verified by scanning events emitted by the LiteSwitch. 
Once a buckydrop payment has been verified (if it was a buckydrop order), then the order is placed with buckydrop. 