### PR TITLE
Fixed price shenanigans and Broken Currency Icon Image

### DIFF
--- a/hamza-client/src/modules/account/components/wishlist/components/wishlist-card.tsx
+++ b/hamza-client/src/modules/account/components/wishlist/components/wishlist-card.tsx
@@ -260,7 +260,7 @@ const WishlistCard: React.FC<WishlistCardProps> = ({
                             >
                                 <Image
                                     className="h-[14px] w-[14px] md:h-[20px] md:w-[20px] self-center"
-                                    src={currencyIcons[currencyCode]}
+                                    src={currencyIcons[currencyCode ?? 'usdc']}
                                     alt={currencyCode}
                                 />
                             </Flex>

--- a/hamza-client/src/modules/common/components/cart-totals/index.tsx
+++ b/hamza-client/src/modules/common/components/cart-totals/index.tsx
@@ -185,8 +185,8 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data }) => {
                         <Flex alignItems={'center'}>
                             <Image
                                 className="h-[14px] w-[14px] md:h-[20px] md:w-[20px]"
-                                src={currencyIcons[currencyCode]}
-                                alt={currencyCode}
+                                src={currencyIcons[currencyCode ?? 'usdc']}
+                                alt={currencyCode ?? 'usdc'}
                             />
                         </Flex>
                         <Text

--- a/hamza-client/src/modules/common/components/line-item-price/index.tsx
+++ b/hamza-client/src/modules/common/components/line-item-price/index.tsx
@@ -99,8 +99,8 @@ const LineItemPrice = ({ item }: LineItemPriceProps) => {
                         <Flex alignItems={'center'}>
                             <Image
                                 className="h-[14px] w-[14px] md:h-[20px] md:w-[20px]"
-                                src={currencyIcons[currencyCode]}
-                                alt={currencyCode}
+                                src={currencyIcons[currencyCode ?? 'usdc']}
+                                alt={currencyCode ?? 'usdc'}
                             />
                         </Flex>
                         <Text

--- a/hamza-client/src/modules/home/components/product-layout/components/product-card.tsx
+++ b/hamza-client/src/modules/home/components/product-layout/components/product-card.tsx
@@ -82,6 +82,7 @@ const ProductCard: React.FC<ProductCardProps & { productId?: string }> = ({
         setLoadingAddToCard(false);
     };
 
+    //TODO: is this used, and why is eth hard-coded?
     // Buy now
     const handleBuyNow = async () => {
         setLoadingBuy(true);
@@ -98,7 +99,7 @@ const ProductCard: React.FC<ProductCardProps & { productId?: string }> = ({
     const whitelistedProductHandler = async () => {
         const whitelistedProduct =
             whitelist_config.is_whitelisted &&
-            whitelist_config.whitelisted_stores.includes(storeId)
+                whitelist_config.whitelisted_stores.includes(storeId)
                 ? true
                 : false;
 

--- a/hamza-client/src/modules/home/components/search-and-filter-panel/components/filter-bar/components/CurrencyModalButton.tsx
+++ b/hamza-client/src/modules/home/components/search-and-filter-panel/components/filter-bar/components/CurrencyModalButton.tsx
@@ -43,7 +43,7 @@ const CurrencyModalButton: React.FC<CurrencyButtonProps> = ({
                 }}
                 onClick={() => setHomeModalCurrencyFilterSelect(currencyName)}
             >
-                <Image src={currencyIcons[currencyName]} alt={currencyName} />
+                <Image src={currencyIcons[currencyName] ?? 'usdc'} alt={currencyName} />
                 <Text
                     fontSize={{ base: '14px', md: '16px' }}
                     ml={{ base: '0.5rem', md: '0.75rem' }}

--- a/hamza-client/src/modules/order/components/summary/index.tsx
+++ b/hamza-client/src/modules/order/components/summary/index.tsx
@@ -117,8 +117,8 @@ const Summary: React.FC<SummaryProps> = ({ cart_id, cart, order }) => {
                             >
                                 <Image
                                     className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                                    src={currencyIcons[product.currency_code]}
-                                    alt={product.currency_code}
+                                    src={currencyIcons[product.currency_code ?? 'usdc']}
+                                    alt={product.currency_code ?? 'usdc'}
                                 />
                             </Flex>
                             <Flex
@@ -133,7 +133,7 @@ const Summary: React.FC<SummaryProps> = ({ cart_id, cart, order }) => {
                                 >
                                     {formatCryptoPrice(
                                         cart.items[index].quantity *
-                                            product.unit_price,
+                                        product.unit_price,
                                         product.currency_code
                                     )}
                                 </Text>

--- a/hamza-client/src/modules/order/components/transaction-details/index.tsx
+++ b/hamza-client/src/modules/order/components/transaction-details/index.tsx
@@ -76,16 +76,16 @@ const TransactionDetails: React.FC<CartTotalsProps> = ({ data }) => {
                             <Flex>
                                 <Image
                                     className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                                    src={currencyIcons[currencyCode]}
-                                    alt={currencyCode}
+                                    src={currencyIcons[currencyCode ?? 'usdc']}
+                                    alt={currencyCode ?? 'usdc'}
                                 />
                                 <Text
                                     ml="0.4rem"
                                     fontSize={{ base: '14px', md: '16px' }}
                                 >
                                     {formatCryptoPrice(
-                                        subtotals[currencyCode],
-                                        currencyCode
+                                        subtotals[currencyCode ?? 'usdc'],
+                                        currencyCode ?? 'usdc'
                                     )}
                                 </Text>
                             </Flex>
@@ -113,8 +113,8 @@ const TransactionDetails: React.FC<CartTotalsProps> = ({ data }) => {
                     <Flex>
                         <Image
                             className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                            src={currencyIcons[currencyCode]}
-                            alt={currencyCode}
+                            src={currencyIcons[currencyCode ?? 'usdc']}
+                            alt={currencyCode ?? 'usdc'}
                         />
                         <Text
                             ml="0.4rem"
@@ -135,8 +135,8 @@ const TransactionDetails: React.FC<CartTotalsProps> = ({ data }) => {
                     <Flex>
                         <Image
                             className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                            src={currencyIcons[currencyCode]}
-                            alt={currencyCode}
+                            src={currencyIcons[currencyCode ?? 'usdc']}
+                            alt={currencyCode ?? 'usdc'}
                         />
                         <Text
                             ml="0.4rem"
@@ -160,8 +160,8 @@ const TransactionDetails: React.FC<CartTotalsProps> = ({ data }) => {
                 <Flex>
                     <Image
                         className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                        src={currencyIcons[currencyCode]}
-                        alt={currencyCode}
+                        src={currencyIcons[currencyCode ?? 'usdc']}
+                        alt={currencyCode ?? 'usdc'}
                     />
                     <Text ml="0.4rem">
                         {formatCryptoPrice(grandTotal, currencyCode)}

--- a/hamza-client/src/modules/products/components/product-actions/index.tsx
+++ b/hamza-client/src/modules/products/components/product-actions/index.tsx
@@ -160,6 +160,7 @@ export default function ProductActions({
         setIsAdding(false);
     };
 
+    //TODO: is this used, and why is eth hard-coded?
     //Add to card and buy now
     //FYI: If user clicks buy now and then navigates back to the product preview and clicks again it will increase quanitity again
     const handleBuyNow = async () => {
@@ -202,7 +203,7 @@ export default function ProductActions({
         if (data.status == true) {
             const whitelistedProduct =
                 whitelist_config.is_whitelisted &&
-                whitelist_config.whitelisted_stores.includes(data.data)
+                    whitelist_config.whitelisted_stores.includes(data.data)
                     ? true
                     : false;
 
@@ -271,10 +272,10 @@ export default function ProductActions({
                     {!variant
                         ? 'Select variant'
                         : !inStock && isWhitelisted
-                          ? 'Add to Cart'
-                          : inStock
                             ? 'Add to Cart'
-                            : 'Out of Stock'}
+                            : inStock
+                                ? 'Add to Cart'
+                                : 'Out of Stock'}
                 </Button>
                 {!inStock && isWhitelisted && (
                     <span className="text-xs">

--- a/hamza-client/src/modules/products/components/product-group-home/component/home-product-card.tsx
+++ b/hamza-client/src/modules/products/components/product-group-home/component/home-product-card.tsx
@@ -155,7 +155,7 @@ const ProductCardHome: React.FC<ProductCardProps & { productId?: string }> = ({
                                     className="h-[18px] w-[18px] md:h-[20px] md:w-[20px]"
                                     src={
                                         currencyIcons[
-                                            preferred_currency_code || 'usdc'
+                                        preferred_currency_code || 'usdc'
                                         ]
                                     }
                                     alt={preferred_currency_code || 'usdc'}

--- a/hamza-client/src/modules/products/components/product-group-store/index.tsx
+++ b/hamza-client/src/modules/products/components/product-group-store/index.tsx
@@ -119,14 +119,14 @@ const ProductCardGroup = () => {
                     const productPricing =
                         variant?.prices?.find(
                             (price: any) =>
-                                price.currency_code === preferred_currency_code
+                                price.currency_code === (preferred_currency_code ?? 'usdc')
                         )?.amount ||
                         variant?.prices?.[0]?.amount ||
                         0; // Get the price for the preferred currency or fallback to the first price
 
                     const formattedPrice = formatCryptoPrice(
                         productPricing ?? 0,
-                        preferred_currency_code as string
+                        (preferred_currency_code ?? 'usdc') as string
                     );
 
                     return (

--- a/hamza-client/src/modules/products/components/product-preview/components/currency-buttons.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/currency-buttons.tsx
@@ -28,8 +28,8 @@ const CurrencyButtonPreview: React.FC<CurrencyButtonPreviewProps> = ({
             >
                 <Image
                     style={{ width: width, height: height }}
-                    src={currencyIcons[currencyName]}
-                    alt={currencyName}
+                    src={currencyIcons[currencyName ?? 'usdc']}
+                    alt={currencyName ?? 'usdc'}
                 />
             </Flex>
         </Flex>

--- a/hamza-client/src/modules/products/components/product-preview/components/preview-checkout.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/preview-checkout.tsx
@@ -89,8 +89,8 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({ productId }) => {
                         <Image
                             key={currency}
                             className="h-[14px] w-[14px] md:h-[20px] md:w-[20px]"
-                            src={currencyIcons[currency]}
-                            alt={currency}
+                            src={currencyIcons[currency ?? 'usdc']}
+                            alt={currency ?? 'usdc'}
                         />
                     ))}
             </>
@@ -175,6 +175,7 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({ productId }) => {
         }
 
         try {
+            //TODO: is this used, and why is eth hard-coded?
             await addToCart({
                 variantId: selectedVariant.id!,
                 quantity: quantity,
@@ -287,7 +288,7 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({ productId }) => {
                 <Flex gap={{ base: '5px', md: '10px' }} mb="-0.5rem">
                     <Image
                         className="h-[14px] w-[14px] md:h-[24px!important] md:w-[24px!important] self-center"
-                        src={currencyIcons[preferred_currency_code ?? 'USDC']}
+                        src={currencyIcons[preferred_currency_code ?? 'usdc']}
                         alt={preferred_currency_code?.toUpperCase() ?? 'USDC'}
                     />
                     <Heading

--- a/hamza-client/src/modules/shop/components/currency-button.tsx
+++ b/hamza-client/src/modules/shop/components/currency-button.tsx
@@ -39,7 +39,7 @@ const CurrencyButton: React.FC<CurrencyButtonProps> = ({ currencyName }) => {
                 }}
                 onClick={() => setCurrencyFilterSelect(currencyName)}
             >
-                <Image src={currencyIcons[currencyName]} alt={currencyName} />
+                <Image src={currencyIcons[currencyName ?? 'usdc']} alt={currencyName ?? 'usdc'} />
                 <Text
                     fontSize={{ base: '14px', md: '16px' }}
                     ml={{ base: '0.5rem', md: '0.75rem' }}

--- a/hamza-client/src/modules/shop/components/filter-tags.tsx
+++ b/hamza-client/src/modules/shop/components/filter-tags.tsx
@@ -35,7 +35,7 @@ const FilterTags = () => {
             );
         }
         if (currencySelect) {
-            const currencyIcon = currencyIcons[currencySelect];
+            const currencyIcon = currencyIcons[currencySelect ?? 'usdc'];
             tags.push(
                 <FilterTag
                     img={currencyIcon}

--- a/hamza-client/src/modules/shop/components/mobile-filter/components/currency-modal-button.tsx
+++ b/hamza-client/src/modules/shop/components/mobile-filter/components/currency-modal-button.tsx
@@ -42,7 +42,7 @@ const CurrencyModalButton: React.FC<CurrencyButtonProps> = ({
                 }}
                 onClick={() => setModalCurrencyFilterSelect(currencyName)}
             >
-                <Image src={currencyIcons[currencyName]} alt={currencyName} />
+                <Image src={currencyIcons[currencyName ?? 'usdc']} alt={currencyName ?? 'usdc'} />
                 <Text
                     fontSize={{ base: '14px', md: '16px' }}
                     ml={{ base: '0.5rem', md: '0.75rem' }}

--- a/hamza-client/src/modules/shop/components/product-card.tsx
+++ b/hamza-client/src/modules/shop/components/product-card.tsx
@@ -150,8 +150,8 @@ const ProductCardStore: React.FC<ProductCardProps & { productId?: string }> = ({
                             <Flex mb="1px">
                                 <Image
                                     className="h-[18px] w-[18px] md:h-[20px] md:w-[20px]"
-                                    src={currencyIcons[currencyCode]}
-                                    alt={currencyCode}
+                                    src={currencyIcons[currencyCode ?? 'usdc']}
+                                    alt={currencyCode ?? 'usdc'}
                                 />
                             </Flex>
 


### PR DESCRIPTION
This fixes two issues: 
1. when not logged in and after clearing cookies, homepage prices are funky
2. when not logged in and after clearing cookies, broken currency icon on prod details page

In the future, always make 'usdc' the ?? fallback for preferred_currency_code; keep in mind that null/undefined preferred_currency_code is a normal condition