### PR TITLE
force us country code only during compilation

### DIFF
--- a/hamza-client/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -18,13 +18,11 @@ type Props = {
 };
 
 export async function generateStaticParams() {
-    const countryCodes = await listRegions().then((regions) =>
-        regions?.map((r) => r.countries.map((c) => c.iso_2)).flat()
-    );
+    //const countryCodes = await listRegions().then((regions) =>
+    //    regions?.map((r) => r.countries.map((c) => c.iso_2)).flat()
+    //);
+    const countryCodes = ['us'];
 
-    if (!countryCodes) {
-        return null;
-    }
 
     const products = await Promise.all(
         countryCodes.map((countryCode) => {


### PR DESCRIPTION
Compiling every page with every country code killls the server during client build, and isn't necessary in any way for any reason.