### PR TITLE
Product query optimize

### DIFF
--- a/hamza-client/src/modules/home/components/search-and-filter-panel/components/filter-bar/components/FilterModal.tsx
+++ b/hamza-client/src/modules/home/components/search-and-filter-panel/components/filter-bar/components/FilterModal.tsx
@@ -76,17 +76,13 @@ const FilterModalHome: React.FC<FilterModalProps> = ({
 
     const [range, setRange] = useState<RangeType>([0, 10000]);
 
-    console.log(
-        `what value is ${homeModalLowerPriceFilterSelect} and ${homeModalUpperPriceFilterSelect}`
-    );
-
     // Extract unique category names with id
     const uniqueCategories: Category[] = data
         ? data.map((category) => ({
-              name: category.name,
-              id: category.id,
-              metadata: category.metadata,
-          }))
+            name: category.name,
+            id: category.id,
+            metadata: category.metadata,
+        }))
         : [];
 
     return (

--- a/hamza-server/src/api/custom/bucky/verify/route.ts
+++ b/hamza-server/src/api/custom/bucky/verify/route.ts
@@ -1,0 +1,49 @@
+import type { MedusaRequest, MedusaResponse, Logger } from '@medusajs/medusa';
+import { RouteHandler } from '../../../route-handler';
+import { Order } from '../../../../models/order';
+import { Payment } from '../../../../models/payment';
+import PaymentVerificationService from '../../../../services/payment-verification';
+import BuckydropService from '../../../../services/buckydrop';
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+    const paymentVerificationService: PaymentVerificationService = req.scope.resolve('paymentVerificationService');
+
+    const handler: RouteHandler = new RouteHandler(
+        req, res, 'POST', '/admin/custom/payments/verify', ['products']
+    );
+
+    await handler.handle(async () => {
+        let orderPayments: { order: Order, payment: Payment }[] = [];
+        const buckydropService: BuckydropService = req.scope.resolve('buckydropService')
+
+        //me minana banana
+        if (handler.hasParam('order_id'))
+            orderPayments = await paymentVerificationService.verifyPayments(handler.inputParams.order_id);
+        else
+            orderPayments = await paymentVerificationService.verifyPayments();
+
+        //if orders are bucky orders, we gotta do something
+        for (let item of orderPayments) {
+            if (item.order.bucky_metadata && item.order.bucky_metadata.status === 'pending') {
+                item.order = await buckydropService.processPendingOrder(item.order.id);
+            }
+        }
+
+        return handler.returnStatus(200, {
+            verified: orderPayments.map(item => {
+                return {
+                    order_id:
+                        item.order.id,
+                    payment_id:
+                        item.payment.id,
+                    amount:
+                        item.payment.amount,
+                    currency:
+                        item.payment.currency_code,
+                    bucky_metadata:
+                        item.order.bucky_metadata
+                }
+            })
+        });
+    });
+};

--- a/hamza-server/src/api/custom/product/filter/route.ts
+++ b/hamza-server/src/api/custom/product/filter/route.ts
@@ -49,7 +49,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         //call productService.getFilteredProducts to get the products, then return them
 
         //HAD TO COMMENT OUT AND PASS ZEROS, BECAUSE FILTER WAS CAUSING SOME PRODUCTS TO NOT SHOW UP -JK (I can explain more)
-        const products = await productService.getFilteredProductsByCategory(
+        const products = await productService.getFilteredProducts(
             categories,
             0, //upperPrice,
             0, //lowerPrice

--- a/hamza-server/src/services/product.ts
+++ b/hamza-server/src/services/product.ts
@@ -22,6 +22,7 @@ import { In, IsNull, Not } from 'typeorm';
 import { createLogger, ILogger } from '../utils/logging/logger';
 import ProductCategoryRepository from '@medusajs/medusa/dist/repositories/product-category';
 import { SeamlessCache } from '../utils/cache/seamless-cache';
+import { filterDuplicatesById } from '../utils/filter-duplicates';
 
 export type BulkImportProductInput = CreateProductInput;
 
@@ -618,7 +619,7 @@ class ProductService extends MedusaProductService {
             );
 
             // Step 6: filter out duplicates
-            filteredProducts = this.filterDuplicatesById(filteredProducts);
+            filteredProducts = filterDuplicatesById(filteredProducts);
 
             // Step 6: Update product pricing for filtered products
             await this.convertPrices(filteredProducts);
@@ -833,19 +834,12 @@ class ProductCache extends SeamlessCache {
         }
 
         //remove duplicates
-        products = this.filterDuplicatesById(products);
+        products = filterDuplicatesById(products);
 
         // Update product pricing
         await params.convertPrices(products);
 
         return products; // Return filtered products
-    }
-
-    private filterDuplicatesById<T extends { id: string }>(items: T[]): T[] {
-        return items.filter(
-            (i, index, array) =>
-                index === array.findIndex((ii) => ii.id === i.id)
-        );
     }
 }
 

--- a/hamza-server/src/services/product.ts
+++ b/hamza-server/src/services/product.ts
@@ -646,14 +646,13 @@ class ProductService extends MedusaProductService {
         lowerPrice: number // Number representing the lower price limit
     ) {
         try {
-
             let normalizedCategoryNames = categories.map((name) =>
                 name.toLowerCase()
             );
             if (normalizedCategoryNames.length > 1 && normalizedCategoryNames[0] === 'all')
                 normalizedCategoryNames = normalizedCategoryNames.slice(1);
 
-            const key = normalizedCategoryNames.join(',');
+            const key = normalizedCategoryNames.sort().join(',');
             console.log('KEY IS', key);
 
             if (productCache[key]) {

--- a/hamza-server/src/services/product.ts
+++ b/hamza-server/src/services/product.ts
@@ -646,13 +646,20 @@ class ProductService extends MedusaProductService {
         lowerPrice: number // Number representing the lower price limit
     ) {
         try {
-            const key = categories.join(',');
-            if (productCache[key])
-                return productCache[key];
 
             let normalizedCategoryNames = categories.map((name) =>
                 name.toLowerCase()
             );
+            if (normalizedCategoryNames.length > 1 && normalizedCategoryNames[0] === 'all')
+                normalizedCategoryNames = normalizedCategoryNames.slice(1);
+
+            const key = normalizedCategoryNames.join(',');
+            console.log('KEY IS', key);
+
+            if (productCache[key]) {
+                this.logger.debug('getFilteredProductsByCategory returning from cache')
+                return productCache[key];
+            }
 
             let products: Product[] = [];
 

--- a/hamza-server/src/services/product.ts
+++ b/hamza-server/src/services/product.ts
@@ -610,7 +610,7 @@ class ProductService extends MedusaProductService {
             }
 
             //remove duplicates
-            products = this.filterDuplicatesById(products);
+            products = filterDuplicatesById(products);
 
             // Update product pricing
             await this.convertPrices(products);

--- a/hamza-server/src/services/product.ts
+++ b/hamza-server/src/services/product.ts
@@ -20,7 +20,6 @@ import CustomerService from '../services/customer';
 import { ProductVariantRepository } from '../repositories/product-variant';
 import { In, IsNull, Not } from 'typeorm';
 import { createLogger, ILogger } from '../utils/logging/logger';
-import ProductCategoryRepository from '@medusajs/medusa/dist/repositories/product-category';
 import { SeamlessCache } from '../utils/cache/seamless-cache';
 import { filterDuplicatesById } from '../utils/filter-duplicates';
 
@@ -774,7 +773,7 @@ class ProductService extends MedusaProductService {
  */
 class CategoryCache extends SeamlessCache {
     constructor() {
-        super(6000);
+        super(parseInt(process.env.CATEGORY_CACHE_EXPIRATION_SECONDS ?? '300'));
     }
 
     async retrieve(params?: any): Promise<ProductCategory[]> {
@@ -801,7 +800,7 @@ class CategoryCache extends SeamlessCache {
  */
 class ProductFilterCache extends SeamlessCache {
     constructor() {
-        super(6000);
+        super(parseInt(process.env.CATEGORY_CACHE_EXPIRATION_SECONDS ?? '300'));
     }
 
     async retrieveWithKey(key?: string, params?: any): Promise<Product[]> {

--- a/hamza-server/src/utils/cache/seamless-cache.ts
+++ b/hamza-server/src/utils/cache/seamless-cache.ts
@@ -3,6 +3,19 @@ type CacheItem = {
     data: any;
 }
 
+/**
+ * A utility for: 
+ * - keeping data in cache for a max number of seconds 
+ * - serving the data in such a way that there isn't a sudden rush for querying 
+ * - service the data in such a way that it's always available 
+ * 
+ * Usage: 
+ * - extend the class 
+ * - implement the getData method such that it retrieves data 
+ * - from the consumer side, call either retrieve or retrieveWithKey
+ * 
+ * @author John R. Kosinski
+ */
 export class SeamlessCache {
     private cache: { [key: string]: CacheItem } = {};
     private expirationSeconds: number;
@@ -11,10 +24,26 @@ export class SeamlessCache {
         this.expirationSeconds = expirationSeconds;
     }
 
+    /**
+     * Get the single item of cached data held in the instance. 
+     * The item will be retrieved by the getData function if it isn't present, and it will be 
+     * refreshed if expired.
+     * 
+     * @param params Anything; these will be passed to the getData function ultimately
+     * @returns cached data of a specifically defined type
+     */
     async retrieve(params?: any): Promise<any> {
         return await this.retrieveWithKey('default', params);
     }
 
+    /**
+     * Get a single item of cached data held in the instance defined by the given unique key. 
+     * The item will be retrieved by the getData function if it isn't present, and it will be 
+     * refreshed if expired.
+     * 
+     * @param params Anything; these will be passed to the getData function ultimately
+     * @returns cached data of a specifically defined type
+     */
     async retrieveWithKey(key?: string, params?: any): Promise<any> {
         if (this.cache[key]?.data && this.isExpired(key)) {
             this.refreshCache(key, params);
@@ -37,6 +66,12 @@ export class SeamlessCache {
         return (Math.floor(Date.now() / 1000) - this.expirationSeconds > this.cache[key]?.timestamp);
     }
 
+    /**
+     * Override this in extended classes to define exactly how to get the data. 
+     * 
+     * @param params 
+     * @returns 
+     */
     protected async getData(params: any): Promise<any> {
         return {};
     }

--- a/hamza-server/src/utils/cache/seamless-cache.ts
+++ b/hamza-server/src/utils/cache/seamless-cache.ts
@@ -1,0 +1,43 @@
+type CacheItem = {
+    timestamp: number;
+    data: any;
+}
+
+export class SeamlessCache {
+    private cache: { [key: string]: CacheItem } = {};
+    private expirationSeconds: number;
+
+    constructor(expirationSeconds: number) {
+        this.expirationSeconds = expirationSeconds;
+    }
+
+    async retrieve(params?: any): Promise<any> {
+        return await this.retrieveWithKey('default', params);
+    }
+
+    async retrieveWithKey(key?: string, params?: any): Promise<any> {
+        if (this.cache[key]?.data && this.isExpired(key)) {
+            this.refreshCache(key, params);
+        } else {
+            await this.refreshCache(key, params);
+        }
+
+        return this.cache[key]?.data;
+    }
+
+    protected async refreshCache(key: string, params: any): Promise<void> {
+        const data: any = await this.getData(params);
+        this.cache[key] = {
+            timestamp: Math.floor(Date.now() / 1000),
+            data: data
+        };
+    }
+
+    protected isExpired(key: string): boolean {
+        return (Math.floor(Date.now() / 1000) - this.expirationSeconds > this.cache[key]?.timestamp);
+    }
+
+    protected async getData(params: any): Promise<any> {
+        return {};
+    }
+}

--- a/hamza-server/src/utils/filter-duplicates.ts
+++ b/hamza-server/src/utils/filter-duplicates.ts
@@ -1,0 +1,8 @@
+
+
+export function filterDuplicatesById<T extends { id: string }>(items: T[]): T[] {
+    return items.filter(
+        (i, index, array) =>
+            index === array.findIndex((ii) => ii.id === i.id)
+    );
+}


### PR DESCRIPTION
This is an emergency measure so that I can add products for right now without slowing down the server. 
This caches the product category query results, as those are taking quite a while to retrieve all of the variants (many variants)
Working on a better solution in the meantime. 