### PR TITLE
Log reform

### DIFF
--- a/hamza-server/src/utils/logging/logger.ts
+++ b/hamza-server/src/utils/logging/logger.ts
@@ -13,46 +13,48 @@ export class DatabaseLogger implements ILogger {
     private readonly logger: Logger;
     private readonly repository: typeof AppLogRepository;
     private readonly prefix: string;
-    private readonly logTypes: string[];
+    private readonly logTypesDb: string[];
+    private readonly logTypesConsole: string[];
 
     constructor(container: any, prefix?: string) {
         this.logger = container.logger;
         this.repository = container.appLogRepository;
         this.prefix = prefix ?? '';
 
-        this.logTypes = process.env.LOG_TO_DATABASE ? process.env.LOG_TO_DATABASE.split(',') : [];
+        this.logTypesDb = process.env.LOG_TO_DATABASE ? process.env.LOG_TO_DATABASE.split(',') : [];
+        this.logTypesConsole = process.env.LOG_TO_CONSOLE ? process.env.LOG_TO_CONSOLE.split(',') : [];
     }
 
     debug(text: any) {
         text = this.prefix?.length ? `${this.prefix}: ${text}` : text;
         this.saveEntry(text, 'debug');
-        if (process.env.LOG_TO_CONSOLE && this.logTypes.includes('debug'))
+        if (process.env.LOG_TO_CONSOLE && this.logTypesConsole.includes('debug'))
             this.logger?.debug(text);
     }
 
     info(text: any) {
         text = this.prefix?.length ? `${this.prefix}: ${text}` : text;
         this.saveEntry(text, 'info');
-        if (process.env.LOG_TO_CONSOLE && this.logTypes.includes('info'))
+        if (process.env.LOG_TO_CONSOLE && this.logTypesConsole.includes('info'))
             this.logger?.info(text);
     }
 
     warn(text: any) {
         text = this.prefix?.length ? `${this.prefix}: ${text}` : text;
         this.saveEntry(text, 'warn');
-        if (process.env.LOG_TO_CONSOLE && this.logTypes.includes('warn'))
+        if (process.env.LOG_TO_CONSOLE && this.logTypesConsole.includes('warn'))
             this.logger?.warn(text);
     }
 
     error(text: any, error?: any) {
         text = this.prefix?.length ? `${this.prefix}: ${text}` : text;
         this.saveEntry(text, 'error', error);
-        if (process.env.LOG_TO_CONSOLE && this.logTypes.includes('error'))
+        if (process.env.LOG_TO_CONSOLE && this.logTypesConsole.includes('error'))
             this.logger?.error(text, error);
     }
 
     private saveEntry(text: string, log_level: string, content?: any) {
-        if (this.logTypes.includes(log_level)) {
+        if (this.logTypesDb.includes(log_level)) {
             const entry = {
                 text,
                 session_id: sessionStorage.sessionId,


### PR DESCRIPTION
LOG_TO_CONSOLE=warn,error,info
LOG_TO_DATABASE=debug,info

Now instead of just '1', these variables can be a comma-delimited list. In the example above, all logs of type warn, error, and info will be logged to console. Types debug and info will be logged to database.