### PR TITLE
Hide zero shipping

### DIFF
--- a/hamza-client/src/modules/common/components/cart-totals/index.tsx
+++ b/hamza-client/src/modules/common/components/cart-totals/index.tsx
@@ -132,7 +132,7 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data }) => {
                     </div>
                 )}
 
-                {shippingCost &&
+                {shippingCost ?
                     <Flex justifyContent={'space-between'}>
                         <Text
                             alignSelf={'center'}
@@ -151,6 +151,7 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data }) => {
                             ).toString()}
                         </Text>
                     </Flex>
+                    : <Flex></Flex>
                 }
 
                 {/* final total */}


### PR DESCRIPTION
Because a shipping cost displayed as '0' might mislead customers (because it can change later), the entire row of Shipping cost is hidden if the shipping cost is zero. 