### PR TITLE
hide saved address button if no saved addresses

### DIFF
--- a/hamza-client/src/modules/checkout/components/addresses/index.tsx
+++ b/hamza-client/src/modules/checkout/components/addresses/index.tsx
@@ -44,9 +44,9 @@ const Addresses = ({
         useToggleState(
             cart?.shipping_address && cart?.billing_address
                 ? compareAddresses(
-                      cart?.shipping_address,
-                      cart?.billing_address
-                  )
+                    cart?.shipping_address,
+                    cart?.billing_address
+                )
                 : true
         );
 
@@ -126,10 +126,12 @@ const Addresses = ({
                                 Edit Shipping Address
                             </Button>
 
-                            <AddressSelect
-                                cart={cart}
-                                addresses={customer?.shipping_addresses ?? []}
-                            />
+                            {(customer?.shipping_addresses?.length ?? 0) > 0 &&
+                                <AddressSelect
+                                    cart={cart}
+                                    addresses={customer?.shipping_addresses ?? []}
+                                />
+                            }
                         </Flex>
                     </Flex>
                 ) : (

--- a/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
@@ -87,7 +87,7 @@ const ShippingAddress = ({
 
     return (
         <>
-            {customer && (addressesInRegion?.length || 0) > 0 && (
+            {customer && (customer?.shipping_addresses?.length ?? 0) && (addressesInRegion?.length || 0) > 0 && (
                 <Container className="mb-6 flex flex-col gap-y-4 p-5">
                     <p className="text-small-regular">
                         {`Hi ${customer.first_name}, do you want to use one of your saved addresses?`}


### PR DESCRIPTION
Hide 'Use Saved Address' button in checkout, if user has no saved addresses. 