### PR TITLE
Selected variant revert fix

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
@@ -282,7 +282,7 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                 setOptions(initialOptions);
             }
         }
-    }, [productData]);
+    }, [productData.id]);
 
     const convertToPriceDictionary = (selectedVariant: Variant | null) => {
         const output: { [key: string]: number } = {};


### PR DESCRIPTION
https://www.notion.so/hamza-market-token/69b72e6412a64c9cb22476b55ab3d62b?v=c3570b8411be49cd8953b6b29bf1c3df&p=1178a92e3a0b80b68296c1196020d8e6&pm=s

## Task Description

Repro: 

- go to the product details page of a product which has variants
- click a variant which isn’t the first one shown
- add to cart

Expected: 

- item adds to cart
- the selected variant is still selected

Actual: 

- correct (selected) variant adds to cart
- the selected variant becomes unselected; first shown variant is selected instead