### PR TITLE
Anon shipping price

### DIFF
--- a/hamza-server/src/services/buckydrop.ts
+++ b/hamza-server/src/services/buckydrop.ts
@@ -173,13 +173,18 @@ export default class BuckydropService extends TransactionBaseService {
                 return 0;
             }
 
+            //get customer if there is one
             if (!cart.customer) {
-                cart.customer = await this.customerService_.retrieve(
-                    cart.customer_id
-                );
+                if (cart.customer_id?.length) {
+                    cart.customer = await this.customerService_.retrieve(
+                        cart.customer_id
+                    );
+                }
             }
 
-            currency = cart.customer.preferred_currency_id;
+            currency = cart.customer ?
+                cart.customer.preferred_currency_id :
+                cart?.items[0]?.currency_code ?? 'usdc';
 
             /*
             //calculate prices
@@ -326,7 +331,7 @@ export default class BuckydropService extends TransactionBaseService {
                 province: cart.billing_address.province ?? '',
                 city: cart.billing_address.city ?? '',
                 detailAddress:
-                    `${cart.billing_address.address_1 ?? ''} ${cart.billing_address.address_2 ?? ''}`.trim(),
+                    `${cart.billing_address.address_1 ?? ''}{' '}${cart.billing_address.address_2 ?? ''}`.trim(),
                 postCode: cart.billing_address.postal_code,
                 contactName:
                     `${cart.billing_address.first_name ?? ''} ${cart.billing_address.last_name ?? ''}`.trim(),


### PR DESCRIPTION
When a customer cart is anonymous, we can't get the preferred currency from the cart's customer record. The currency is necessary for calculating shipping cost in the right currency.
Therefore, we have to get the currency from the cart itself. 
If the cart is empty, the shipping cost is just 0. If there is at least one item in the cart. and the cart is anonymous, the currency is taken from the first cart item. 