### PR TITLE
Cart merge fix

### DIFF
--- a/hamza-server/src/services/cart.ts
+++ b/hamza-server/src/services/cart.ts
@@ -150,41 +150,52 @@ export default class CartService extends MedusaCartService {
         //get last cart
         const carts = await this.cartRepository_.find({
             where: {
-                customer_id: customerId,
-                id: Not(cartId),
-                completed_at: IsNull(),
-                deleted_at: IsNull()
+                customer_id: customerId
             },
             order: { updated_at: 'DESC' },
             take: 1,
         });
 
+        let previousCart = carts?.length ? carts[0] : null;
+
+        //don't consider previous cart if completed or deleted
+        if (previousCart) {
+            if (previousCart.deleted_at || previousCart.completed_at)
+                previousCart = null;
+        }
+
         //is there also a non-logged-in cart from cookies? 
-        const existingCart = await this.cartRepository_.findOne(
-            {
-                where: {
-                    id: cartId,
-                    completed_at: IsNull(),
-                    deleted_at: IsNull()
+        let anonCart = null;
+        if (cartId?.length && cartId != previousCart?.id) {
+            anonCart = await this.cartRepository_.findOne(
+                {
+                    where: {
+                        id: cartId,
+                        completed_at: IsNull(),
+                        deleted_at: IsNull()
+                    }
                 }
-            }
-        );
+            );
+        }
 
-        //only return if the most recent one is not completed
+
+        //if only anon cart, use that 
         let cart = null;
-        if (carts.length > 0) {
-            if (!carts[0].completed_at) cart = carts[0];
+        if (!previousCart && anonCart) {
+            cart = anonCart;
         }
+        else {
+            //use previous user cart by default
+            cart = previousCart;
 
-        if (!cart && existingCart) {
-            cart = existingCart;
-        }
-        else if (cart && existingCart) {
-            //merge carts
-            cart = await this.mergeCarts(cart, existingCart);
-        }
+            //and if there's an anon cart too, merge it in
+            if (anonCart) {
+                //merge carts
+                cart = await this.mergeCarts(previousCart, anonCart);
+            }
 
-        return cart;
+            return cart;
+        }
     }
 
     async addDefaultShippingMethod(cartId: string, force: boolean = false): Promise<void> {


### PR DESCRIPTION
Revised logic for merging carts. 
- not considering passed-in cart id if it's null or empty
- get completed & deleted carts, but ignore them 
- don't consider passed-in cart id if it's identical to retrieved cart id
- above all, don't use id: Not(cartId) in query; it has unpredictable results