### PR TITLE
hns changes

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -537,7 +537,10 @@ export async function setCartEmail(cart_id: string, email_address: string) {
 
 export async function recoverCart(customer_id: string) {
     const cart_id = cookies().get('_medusa_cart_id')?.value;
-    const output = await getSecure('/custom/cart/recover', { customer_id, cart_id });
+    const output = await getSecure('/custom/cart/recover', {
+        customer_id,
+        cart_id,
+    });
     if (output?.cart) {
         cookies().set('_medusa_cart_id', output.cart.id);
     }

--- a/hamza-client/src/modules/layout/templates/nav/index.tsx
+++ b/hamza-client/src/modules/layout/templates/nav/index.tsx
@@ -10,7 +10,7 @@ import Image from 'next/image';
 //import HamzaTitle2 from '../../../../../public/images/logo/nav-logo.svg';
 import HamzaLogo from '../../../../../public/images/logo/hamza-beta.png';
 //  Components
-
+import HnsDisplay from './menu-desktop/hns-display/index';
 import NavSearchBar from './menu-desktop/components/nav-searchbar';
 import MobileMenu from './menu-mobile/menu/mobile-main-menu';
 import MobileNav from './menu-mobile/mobile-nav';
@@ -107,6 +107,7 @@ export default async function Nav() {
 
                     <NavSearchBar />
 
+                    <HnsDisplay />
                     <MainMenu />
 
                     <WalletConnectButton />

--- a/hamza-client/src/modules/layout/templates/nav/menu-desktop/account-menu.tsx
+++ b/hamza-client/src/modules/layout/templates/nav/menu-desktop/account-menu.tsx
@@ -37,7 +37,6 @@ const AccountMenu = () => {
                 <MenuButton
                     width={'60px'}
                     height={'57px'}
-                    px="1rem"
                     borderRadius={'full'}
                     borderColor={'white'}
                     borderWidth={'1px'}

--- a/hamza-client/src/modules/layout/templates/nav/menu-desktop/hns-display/index.tsx
+++ b/hamza-client/src/modules/layout/templates/nav/menu-desktop/hns-display/index.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { MdWallet } from 'react-icons/md';
+import { useCustomerAuthStore } from '@store/customer-auth/customer-auth';
+import { Flex, Text, Input } from '@chakra-ui/react';
+import { useState } from 'react';
+
+const HnsDisplay = () => {
+    const { authData, hnsName } = useCustomerAuthStore();
+    const [isCopied, setIsCopied] = useState(false);
+
+    const displayHns =
+        hnsName && hnsName.trim() !== ''
+            ? hnsName
+            : authData?.wallet_address
+              ? `${authData.wallet_address.slice(0, 4)}...${authData.wallet_address.slice(-4)}`
+              : '';
+
+    // Full address for copying
+    const fullAddress =
+        hnsName && hnsName.trim() !== ''
+            ? hnsName
+            : authData?.wallet_address || '';
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(fullAddress).then(() => {
+            setIsCopied(true);
+            setTimeout(() => setIsCopied(false), 2000); // Reset copy status after 2 seconds
+        });
+    };
+
+    return authData.status === 'authenticated' ? (
+        <Flex
+            mx={'24px'}
+            color={'white'}
+            backgroundColor={'#121212'}
+            opacity={'90%'}
+            flexDirection={'row'}
+            alignItems={'center'}
+            width={'180px'}
+            height={'48px'}
+            padding={'14px'}
+            cursor="pointer"
+            rounded={'lg'}
+            onClick={handleCopy}
+        >
+            <MdWallet />
+            <Text
+                ml="8px"
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
+            >
+                {displayHns}
+            </Text>
+            <Input type="hidden" value={fullAddress} readOnly />
+            {isCopied && (
+                <Text ml="8px" color="green.300" fontSize="sm">
+                    Copied!
+                </Text>
+            )}
+        </Flex>
+    ) : (
+        <></>
+    );
+};
+
+export default HnsDisplay;

--- a/hamza-client/src/modules/layout/templates/nav/menu-mobile/menu/mobile-account-menu.tsx
+++ b/hamza-client/src/modules/layout/templates/nav/menu-mobile/menu/mobile-account-menu.tsx
@@ -37,7 +37,6 @@ const MobileAccountMenu = () => {
             <MenuButton
                 width={'26px'}
                 height={'26px'}
-                px="5px"
                 borderRadius={'full'}
                 borderColor={'white'}
                 borderWidth={'1px'}


### PR DESCRIPTION
- Avatar image takes up whole container
- Applied to mobile
- Added `HNS Name ?? Wallet_Address` to Desktop Navbar
- Can copy HNS Name || Wallet_Address onClick

Steps to test
- If logged out, there should not be a component beside the hamburger menu
- If logged in without HNS, it should show wallet address
- If logged in with HNS, HNS Name should show beside hamburger menu

https://www.notion.so/hamza-market-token/HNS-Integration-2-Name-Display-12c8a92e3a0b80548493c986f0037257?pvs=4