### PR TITLE
Duplicated data in Orders per Item

### DIFF
--- a/hamza-client/src/modules/order/templates/cancelled.tsx
+++ b/hamza-client/src/modules/order/templates/cancelled.tsx
@@ -140,60 +140,67 @@ const Cancelled = ({
                                                         {/*)}*/}
                                                     </Text>
                                                 </Flex>
-                                                <Flex
-                                                    direction={{
-                                                        base: 'column',
-                                                        md: 'row',
-                                                    }}
-                                                    justifyContent={'flex-end'}
-                                                    gap={2}
-                                                    mt={{ base: 4, md: 0 }}
-                                                    width="100%"
-                                                >
-                                                    <Button
-                                                        variant="outline"
-                                                        colorScheme="white"
-                                                        borderRadius={'37px'}
-                                                        onClick={() =>
-                                                            setActiveOrder(
-                                                                order.id
-                                                            )
-                                                        } // Set active order on click
-                                                        width={{
-                                                            base: '100%',
-                                                            md: 'auto',
+                                                {index ===
+                                                order.items.length - 1 ? (
+                                                    <Flex
+                                                        direction={{
+                                                            base: 'column',
+                                                            md: 'row',
                                                         }}
-                                                    >
-                                                        View Cancellation
-                                                        Details
-                                                    </Button>
-                                                    <a
-                                                        href="https://blog.hamza.market/contact/"
-                                                        target="_blank"
+                                                        justifyContent={
+                                                            'flex-end'
+                                                        }
+                                                        gap={2}
+                                                        mt={{ base: 4, md: 0 }}
+                                                        width="100%"
                                                     >
                                                         <Button
-                                                            ml={{
-                                                                base: 0,
-                                                                md: 2,
-                                                            }}
-                                                            mt={{
-                                                                base: 2,
-                                                                md: 0,
-                                                            }}
                                                             variant="outline"
                                                             colorScheme="white"
                                                             borderRadius={
                                                                 '37px'
                                                             }
+                                                            onClick={() =>
+                                                                setActiveOrder(
+                                                                    order.id
+                                                                )
+                                                            } // Set active order on click
                                                             width={{
                                                                 base: '100%',
                                                                 md: 'auto',
                                                             }}
                                                         >
-                                                            Contact Seller
+                                                            View Cancellation
+                                                            Details
                                                         </Button>
-                                                    </a>
-                                                </Flex>
+                                                        <a
+                                                            href="https://blog.hamza.market/contact/"
+                                                            target="_blank"
+                                                        >
+                                                            <Button
+                                                                ml={{
+                                                                    base: 0,
+                                                                    md: 2,
+                                                                }}
+                                                                mt={{
+                                                                    base: 2,
+                                                                    md: 0,
+                                                                }}
+                                                                variant="outline"
+                                                                colorScheme="white"
+                                                                borderRadius={
+                                                                    '37px'
+                                                                }
+                                                                width={{
+                                                                    base: '100%',
+                                                                    md: 'auto',
+                                                                }}
+                                                            >
+                                                                Contact Seller
+                                                            </Button>
+                                                        </a>
+                                                    </Flex>
+                                                ) : null}
                                             </Flex>
                                         </div>
                                     )

--- a/hamza-client/src/modules/order/templates/processing.tsx
+++ b/hamza-client/src/modules/order/templates/processing.tsx
@@ -271,73 +271,64 @@ const Processing = ({
                                                 />
 
                                                 {/* Right-aligned buttons */}
-                                                <Flex
-                                                    direction={{
-                                                        base: 'column',
-                                                        md: 'row',
-                                                    }}
-                                                    justifyContent={'flex-end'}
-                                                    gap={2}
-                                                    mt={{ base: 4, md: 0 }}
-                                                    width="100%"
-                                                >
-                                                    <Button
-                                                        variant="outline"
-                                                        colorScheme="white"
-                                                        borderRadius="37px"
-                                                        cursor="pointer"
-                                                        ml={{
-                                                            base: 0,
-                                                            md: 2,
+                                                {index ===
+                                                order.items.length - 1 ? (
+                                                    <Flex
+                                                        direction={{
+                                                            base: 'column',
+                                                            md: 'row',
                                                         }}
-                                                        mt={{
-                                                            base: 2,
-                                                            md: 0,
-                                                        }}
-                                                        width={{
-                                                            base: '100%',
-                                                            md: 'auto',
-                                                        }}
-                                                        _hover={{
-                                                            textDecoration:
-                                                                'underline',
-                                                        }}
-                                                        onClick={() =>
-                                                            toggleViewOrder(
-                                                                item.id
-                                                            )
+                                                        justifyContent={
+                                                            'flex-end'
                                                         }
+                                                        gap={2}
+                                                        mt={{ base: 4, md: 0 }}
+                                                        width="100%"
                                                     >
-                                                        View Order
-                                                    </Button>
-                                                    {index ===
-                                                    order.items.length - 1 ? (
-                                                        order.status ===
-                                                        'canceled' ? (
-                                                            <Button
-                                                                colorScheme="red"
-                                                                isDisabled
-                                                            >
-                                                                Cancellation
-                                                                Requested
-                                                            </Button>
-                                                        ) : (
-                                                            <Button
-                                                                variant="outline"
-                                                                colorScheme="white"
-                                                                borderRadius="37px"
-                                                                onClick={() =>
-                                                                    openModal(
-                                                                        order.id
-                                                                    )
-                                                                }
-                                                            >
-                                                                Request
-                                                                Cancellation
-                                                            </Button>
-                                                        )
-                                                    ) : null}
-                                                </Flex>
+                                                        <Button
+                                                            variant="outline"
+                                                            colorScheme="white"
+                                                            borderRadius="37px"
+                                                            cursor="pointer"
+                                                            ml={{
+                                                                base: 0,
+                                                                md: 2,
+                                                            }}
+                                                            mt={{
+                                                                base: 2,
+                                                                md: 0,
+                                                            }}
+                                                            width={{
+                                                                base: '100%',
+                                                                md: 'auto',
+                                                            }}
+                                                            _hover={{
+                                                                textDecoration:
+                                                                    'underline',
+                                                            }}
+                                                            onClick={() =>
+                                                                toggleViewOrder(
+                                                                    item.id
+                                                                )
+                                                            }
+                                                        >
+                                                            View Order
+                                                        </Button>
+
+                                                        <Button
+                                                            variant="outline"
+                                                            colorScheme="white"
+                                                            borderRadius="37px"
+                                                            onClick={() =>
+                                                                openModal(
+                                                                    order.id
+                                                                )
+                                                            }
+                                                        >
+                                                            Request Cancellation
+                                                        </Button>
+                                                    </Flex>
+                                                ) : null}
                                             </Flex>
 
                                             {/* Collapsible Section */}
@@ -482,7 +473,7 @@ const Processing = ({
                                                                                 //         hour12: true,
                                                                                 //     }
                                                                                 // )}`,
-                                                                                paymentDetails: `Paid with ${item.currency_code.toUpperCase()}. Total payment: ${getAmount(item.unit_price, item.currency_code)} ${item.currency_code.toUpperCase()}`,
+                                                                                paymentDetails: `Paid with ${item.currency_code.toUpperCase()}. Total payment: ${getAmount(totalPrice, item.currency_code)} ${item.currency_code.toUpperCase()}`,
                                                                                 // receiptLink:
                                                                                 //     'View receipt',
                                                                             },
@@ -659,22 +650,22 @@ const Processing = ({
                                                                                     }
                                                                                 </Text>
                                                                             </Box>
-                                                                            <Box>
-                                                                                <Text
-                                                                                    fontSize="sm"
-                                                                                    color="gray.400"
-                                                                                >
-                                                                                    Item
-                                                                                    ID:
-                                                                                </Text>
-                                                                                <Flex flexWrap="wrap">
-                                                                                    <Text fontWeight="bold">
-                                                                                        {
-                                                                                            item.id
-                                                                                        }
-                                                                                    </Text>
-                                                                                </Flex>
-                                                                            </Box>
+                                                                            {/*<Box>*/}
+                                                                            {/*    <Text*/}
+                                                                            {/*        fontSize="sm"*/}
+                                                                            {/*        color="gray.400"*/}
+                                                                            {/*    >*/}
+                                                                            {/*        Item*/}
+                                                                            {/*        ID:*/}
+                                                                            {/*    </Text>*/}
+                                                                            {/*    <Flex flexWrap="wrap">*/}
+                                                                            {/*        <Text fontWeight="bold">*/}
+                                                                            {/*            {*/}
+                                                                            {/*                item.id*/}
+                                                                            {/*            }*/}
+                                                                            {/*        </Text>*/}
+                                                                            {/*    </Flex>*/}
+                                                                            {/*</Box>*/}
                                                                             <Box>
                                                                                 <Text
                                                                                     fontSize="sm"


### PR DESCRIPTION
Repro: 

- create an order with multiple items in it
- view Orders panel in User Settings

Expected: 

- there is one and only one Order History tab or button for each order, and not one for each item in an order. After all, each order is a unit, and shares a single order history

https://www.notion.so/hamza-market-token/Duplicated-data-in-Orders-per-Item-1278a92e3a0b802c8148fa6f44325709?pvs=4