### PR TITLE
Bug fix: cart recovery recovers completed cart

### DIFF
--- a/hamza-server/src/services/cart.ts
+++ b/hamza-server/src/services/cart.ts
@@ -149,13 +149,16 @@ export default class CartService extends MedusaCartService {
         //get last cart
         const carts = await this.cartRepository_.find({
             where: {
-                customer_id: customerId
+                customer_id: customerId,
+                completed_at: IsNull(),
+                deleted_at: IsNull(),
             },
             order: { updated_at: 'DESC' },
             take: 1,
         });
 
         let previousCart = carts?.length ? carts[0] : null;
+        console.log('previous cart: ', previousCart);
 
         //don't consider previous cart if completed or deleted
         if (previousCart) {
@@ -163,27 +166,23 @@ export default class CartService extends MedusaCartService {
                 previousCart = null;
         }
 
-        //is there also a non-logged-in cart from cookies? 
+        //is there also a non-logged-in cart from cookies?
         let anonCart = null;
         if (cartId?.length && cartId != previousCart?.id) {
-            anonCart = await this.cartRepository_.findOne(
-                {
-                    where: {
-                        id: cartId,
-                        completed_at: IsNull(),
-                        deleted_at: IsNull()
-                    }
-                }
-            );
+            anonCart = await this.cartRepository_.findOne({
+                where: {
+                    id: cartId,
+                    completed_at: IsNull(),
+                    deleted_at: IsNull(),
+                },
+            });
         }
 
-
-        //if only anon cart, use that 
+        //if only anon cart, use that
         let cart = null;
         if (!previousCart && anonCart) {
             cart = anonCart;
-        }
-        else {
+        } else {
             //use previous user cart by default
             cart = previousCart;
 
@@ -197,7 +196,10 @@ export default class CartService extends MedusaCartService {
         }
     }
 
-    async addDefaultShippingMethod(cartId: string, force: boolean = false): Promise<void> {
+    async addDefaultShippingMethod(
+        cartId: string,
+        force: boolean = false
+    ): Promise<void> {
         const cart = await super.retrieve(cartId, {
             relations: ['shipping_methods'],
         });
@@ -280,27 +282,28 @@ export default class CartService extends MedusaCartService {
 
     private async mergeCarts(cart1: Cart, cart2: Cart): Promise<Cart> {
         try {
-            //make sure both carts contain items 
+            //make sure both carts contain items
             if (!cart2?.items) {
-                cart2 = await this.cartRepository_.findOne(
-                    { where: { id: cart2.id }, relations: ['items'] }
-                );
+                cart2 = await this.cartRepository_.findOne({
+                    where: { id: cart2.id },
+                    relations: ['items'],
+                });
             }
 
             if (cart2?.items.length) {
                 if (!cart1.items) {
-                    cart1 = await this.cartRepository_.findOne(
-                        { where: { id: cart1.id }, relations: ['items'] }
-                    );
+                    cart1 = await this.cartRepository_.findOne({
+                        where: { id: cart1.id },
+                        relations: ['items'],
+                    });
                 }
 
                 //move cart 2's line items to cart 1
-                await this.addOrUpdateLineItems(
-                    cart1.id, cart2.items, { validateSalesChannels: false }
-                );
+                await this.addOrUpdateLineItems(cart1.id, cart2.items, {
+                    validateSalesChannels: false,
+                });
             }
-        }
-        catch (e) {
+        } catch (e) {
             this.logger.error('Error merging carts', e);
         }
 


### PR DESCRIPTION
Cart recovery refers to when your last used cart is recovered and associated with your session when you log in. 
It should not recover already-completed (finalized, checked-out) carts. 

- added code to ignore carts with a completed_at date when recovering cart
- set completed_at date when finalizing cart in checkout 

https://www.notion.so/hamza-market-token/Cart-recover-recovers-canceled-carts-1348a92e3a0b804d98fed4522ec6ad84?pvs=23

To test: 

Before: 
- add items to cart
- successfully check out 
- log out 
- log back in as same user 
- check your cart
- notice that it contains the items you just bought

After: 
- follow same steps 
- notice that your cart is empty after logging back in