### PR TITLE
HAM-1849-Checkout-Show existing email in address form

### DIFF
--- a/hamza-client/src/modules/checkout/components/address-modal/index.tsx
+++ b/hamza-client/src/modules/checkout/components/address-modal/index.tsx
@@ -90,7 +90,11 @@ const AddressModal: React.FC<AddressModalProps> = ({
                         cart.shipping_address.country_code || countryCode || '',
                     'shipping_address.province':
                         cart.shipping_address.province || '',
-                    email: cart.email || '',
+                    email: cart?.email
+                        ? cart.email
+                        : customer?.email?.includes('evm')
+                          ? ''
+                          : customer?.email || '',
                     'shipping_address.phone': cart.shipping_address.phone || '',
                 }));
             }
@@ -420,31 +424,17 @@ const AddressModal: React.FC<AddressModalProps> = ({
                                         type="email"
                                         title="Enter a valid email address."
                                         autoComplete="email"
-                                        color="white"
+                                        color={'white'}
                                         _placeholder={{ color: 'white' }}
-                                        value={
-                                            formData.email
-                                                ? formData.email
-                                                : customer?.email?.includes(
-                                                        '@evm.blockchain'
-                                                    )
-                                                  ? ''
-                                                  : customer?.email || ''
-                                        }
+                                        value={formData.email}
+                                        placeholder="Email"
                                         onChange={handleChange}
                                         maxLength={50}
-                                        placeholder={
-                                            customer?.email?.includes(
-                                                '@evm.blockchain'
-                                            )
-                                                ? 'Email'
-                                                : customer?.email || 'Email'
-                                        }
-                                        height="50px"
-                                        fontSize="14px"
-                                        bgColor="#040404"
+                                        height={'50px'}
+                                        fontSize={'14px'}
+                                        bgColor={'#040404'}
                                         borderWidth={0}
-                                        borderRadius="12px"
+                                        borderRadius={'12px'}
                                     />
                                 </FormControl>
                             </Flex>


### PR DESCRIPTION
Address Modal Form
---------------------
Expected:
When opening the address modal if there is no email in cart.email and customer.email is not the default "evm", show the verified email inside the email input.

Steps:
-Have an empty cart and make sure you clean application cache so the previous address data is not shown in checkout
-Verify email address in account
-Add item to cart and checkout
-Set you shipping address in "Address Modal"
-Verified email should appear in email input
-Email input should be able to be modified
-Setting address should show modified email next time you edit address

https://www.notion.so/hamza-market-token/4041e3fafc634bdea249d966286493ba?v=9bf2df12247845958007ddb76976315c&p=1348a92e3a0b803f91dec37dbaaeeeb7&pm=s
