### PR TITLE
HAM-1874-hamza-logo

### DIFF
--- a/hamza-client/src/modules/layout/templates/nav/menu-mobile/mobile-nav.tsx
+++ b/hamza-client/src/modules/layout/templates/nav/menu-mobile/mobile-nav.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import LocalizedClientLink from '@modules/common/components/localized-client-link';
 import { Flex, Text } from '@chakra-ui/react';
 import Image from 'next/image';
-//import HamzaLogo from '../../../../../../public/images/logo/logo_green.svg';
-//import HamzaTitle from '../../../../../../public/images/logo/hamza-title.svg';
-import HamzaLogo from '../../../../../../public/images/logo/hamza-beta.png';
+import HamzaLogo from '../../../../../../public/images/logo/logo_green.svg';
+import HamzaTitle from '../../../../../../public/images/logo/hamza-title.svg';
+// import HamzaLogo from '../../../../../../public/images/logo/hamza-beta.png';
 import MobileMainMenu from './menu/mobile-main-menu';
 import { WalletConnectButton } from './connect-wallet/connect-button';
 import CartButtonMobile from './components/cart-button';
@@ -28,7 +28,7 @@ export default async function MobileNav() {
                 <Flex flex={1} justifyContent={'center'}>
                     <LocalizedClientLink href="/">
                         <Flex>
-                            {/*<Image
+                            <Image
                                 className="w-[22.92px] h-[33px] md:w-[47.34px] md:h-[67px]"
                                 src={HamzaLogo}
                                 alt="Hamza"
@@ -40,14 +40,6 @@ export default async function MobileNav() {
                                 style={{
                                     alignSelf: 'center',
                                 }}
-                                alt="Hamza"
-                            />*/}
-
-                            <Image
-                                style={{
-                                    alignSelf: 'left',
-                                }}
-                                src={HamzaLogo}
                                 alt="Hamza"
                             />
                         </Flex>


### PR DESCRIPTION
Brought back old logo for mobile since it does not exist in our assets and this is currently a lot better than what we have now (which is broken on mobile) - trying to manipulate the size distorts image

https://www.notion.so/hamza-market-token/4041e3fafc634bdea249d966286493ba?v=9bf2df12247845958007ddb76976315c&p=1378a92e3a0b80279032e1a82dd98842&pm=s

Steps
- minimize screen and see the update logo image