### PR TITLE
 HAM-1853: Removed Payment Method from Thankyou Page

### DIFF
--- a/hamza-client/src/modules/order/components/order-details/index.tsx
+++ b/hamza-client/src/modules/order/components/order-details/index.tsx
@@ -66,20 +66,6 @@ const OrderDetails = ({ order, showStatus }: OrderDetailsProps) => {
                         })}
                     </Text>
                 </Flex>
-                <Flex
-                    mt={{ base: '1rem', md: '0' }}
-                    ml={{ base: '0', md: 'auto' }}
-                    flexDir={'column'}
-                    width={'200px'}
-                >
-                    <Text
-                        fontWeight={600}
-                        fontSize={{ base: '14px', md: '16px' }}
-                    >
-                        Payment Method
-                    </Text>
-                    <Text fontSize={{ base: '14px', md: '16px' }}>Crypto</Text>
-                </Flex>
             </Flex>
 
             <Flex


### PR DESCRIPTION
https://www.notion.so/hamza-market-token/Get-rid-of-Payment-Method-on-Thankyou-page-1348a92e3a0b8029833de670b0d15f41?pvs=23

To test: 
- place an order
- view thankyou page 
- Payment Method: Crypto should not appear on it