### PR TITLE
HAMSTR-22: ETH price wrong

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
@@ -192,7 +192,12 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
 
                     // Update USD price if the preferred currency is 'eth'
                     if (isEthCurrency) {
-                        setUsdPrice(price);
+                        setUsdPrice(
+                            getPriceByCurrency(
+                                selectedProductVariant.prices,
+                                'usdc'
+                            )
+                        );
                     }
 
                     // Update the selected price


### PR DESCRIPTION
Changed a couple wrong values passed on the product details page code. 

To test: 
Set preferred currency to eth 
go to product details page
check the eth price shown 
Expected: it’s correct
