### PR TITLE
HAMSTR-55: Removed stray 0, removed Flagship Store from store page

### DIFF
--- a/hamza-client/src/app/[countryCode]/(main)/store/[slug]/components/store-content.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/store/[slug]/components/store-content.tsx
@@ -149,11 +149,6 @@ export default function StoreContent({ params }: { params: { slug: string } }) {
                                     {/* Display the capitalized slug */}
                                 </Text>
                                 <Flex color="#555555" gap={'7px'}>
-                                    <Text
-                                        fontSize={{ base: '10px', md: '16px' }}
-                                    >
-                                        Flagship Store
-                                    </Text>
                                     <Box
                                         alignSelf={'center'}
                                         width={{ base: '2.53px', md: '7.33px' }}
@@ -212,7 +207,7 @@ export default function StoreContent({ params }: { params: { slug: string } }) {
                                         color="primary.green.900"
                                     >
                                         {reviewStats.reviewCount === 0
-                                            ? 0
+                                            ? ''
                                             : `${reviewStats.avgRating.toFixed(1)}`}
                                     </Text>
                                     <Text


### PR DESCRIPTION
 Removed stray 0, removed Flagship Store from store page

Store page just had a big unexplained '0' on it if there were no reviews for the store; now just removed. 
Also all stores had a big 'Flagship Store' on them, hard-coded. Also removed. 

Test: nothing to test, maybe just look @ store page