### PR TITLE
HAMSTR-44 Auto-refresh shipping when items removed

### DIFF
--- a/hamza-client/src/modules/common/components/cart-totals/index.tsx
+++ b/hamza-client/src/modules/common/components/cart-totals/index.tsx
@@ -36,7 +36,7 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data, useCartStyle }) => {
     const [shippingCost, setShippingCost] = useState<number>(0);
     const { shipping_options, isLoading } = useCartShippingOptions(data.id);
 
-    useEffect(() => {
+    const updateShippingCost = () => {
         const url = `${process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || 'http://localhost:9000'}/custom/cart/shipping`;
         axios
             .get(url, {
@@ -48,12 +48,18 @@ const CartTotals: React.FC<CartTotalsProps> = ({ data, useCartStyle }) => {
             .then((response) => {
                 setShippingCost(response?.data?.amount ?? 0);
             });
+    };
+
+    useEffect(() => {
+        updateShippingCost();
     }, [shipping_options, isLoading]);
 
     //TODO: this can be replaced later by extending the cart, if necessary
     const getCartSubtotal = (cart: any, currencyCode: string) => {
         const subtotals: { [key: string]: number } = {};
         const itemCurrencyCode: string = currencyCode;
+
+        updateShippingCost();
 
         for (let n = 0; n < cart.items.length; n++) {
             const item: ExtendedLineItem = cart.items[n];


### PR DESCRIPTION
**Repro:** 
- put 2 items in cart, each from a different store 
- go to checkout 
- observe shipping cost 
- remove one item from cart on checkout page 
- observe shipping cost

**Expected:** 
- shipping cost changes, because each store has its own fixed shipping cost 

**Actual:**
- it does not, (unless you refresh the page; then it corrects

**NOTE:** after refreshing the page, the shipping cost corrects itself. It should automatically correct itself when the item is removed. 