### PR TITLE
HAMSTR-59: Ships from & Shipping time

### DIFF
--- a/hamza-client/src/modules/terms-of-service/product-details-tos.tsx
+++ b/hamza-client/src/modules/terms-of-service/product-details-tos.tsx
@@ -181,12 +181,19 @@ const TermsOfService: React.FC<TermsOfServiceProps> = ({ metadata }) => {
                 </Flex>
 
                 <UnorderedList color={'white'}>
-                    <ListItem fontSize={{ base: '14px', md: '16px' }}>
-                        {metadata?.ships_from ?? ''}
-                    </ListItem>
-                    <ListItem mt="1rem" fontSize={{ base: '14px', md: '16px' }}>
-                        {metadata?.shipping_time ?? ''}{' '}
-                    </ListItem>
+                    {metadata?.ships_from?.length && (
+                        <ListItem fontSize={{ base: '14px', md: '16px' }}>
+                            {metadata?.ships_from ?? ''}
+                        </ListItem>
+                    )}
+                    {metadata?.shipping_time?.length && (
+                        <ListItem
+                            mt="1rem"
+                            fontSize={{ base: '14px', md: '16px' }}
+                        >
+                            {metadata?.shipping_time ?? ''}{' '}
+                        </ListItem>
+                    )}
                 </UnorderedList>
 
                 {/* Modal with Three Options */}


### PR DESCRIPTION
Motivation: Not all products have the same 'ships from' and 'shipping time' 

Solution: Ships from and shipping time are stored in product metadata. A slight change to the frontend to display them dynamically instead of hard-coding them. 

To test: no easy way to test. 
Test on staging.hamza.biz: 
- view product details for a Stanzo product
- view product details for a Snapchum product
- view product details for a gift card 
- look for the "Ships from" and "Shipping time" right under it (bottom right of product data) 