### PR TITLE
HAMSTR-58: usdc equivalent prices not showing in store

### DIFF
--- a/hamza-client/src/lib/util/prices.ts
+++ b/hamza-client/src/lib/util/prices.ts
@@ -5,6 +5,7 @@ import { Region, Variant } from '@/types/medusa';
 import { isEmpty } from './isEmpty';
 import { ProductVariantInfo, RegionInfo } from '../../types/global';
 import { noDivisionCurrencies } from '@lib/constants';
+import { formatCryptoPrice } from './get-product-price';
 
 export const findCheapestRegionPrice = (
     variants: Variant[],
@@ -293,6 +294,21 @@ const convertToLocale = ({
         minimumFractionDigits,
         maximumFractionDigits,
     };
+};
+
+export const formatPriceBetweenCurrencies = (
+    variant_prices: Array<any>,
+    from_currency_code: string,
+    to_currency_code: string
+) => {
+    let formattedPrice: string | number = '';
+    if (from_currency_code === 'eth') {
+        const fromPrice = variant_prices.find(
+            (price: any) => price.currency_code === to_currency_code
+        )?.amount || variant_prices?.[0]?.amount;
+        formattedPrice = formatCryptoPrice(fromPrice ?? 0, to_currency_code);
+    }
+    return formattedPrice;
 };
 
 type ConvertToLocaleParams = {

--- a/hamza-client/src/modules/products/components/product-group-store/index.tsx
+++ b/hamza-client/src/modules/products/components/product-group-store/index.tsx
@@ -15,6 +15,7 @@ import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth';
 import ProductCard from '../product-card/product-card';
 import { formatCryptoPrice } from '@lib/util/get-product-price';
 import useVendor from '@/zustand/store-page/vendor';
+import { formatPriceBetweenCurrencies } from '@/lib/util/prices';
 
 type Props = {
     storeName: string;
@@ -128,6 +129,12 @@ const ProductCardGroup = ({ storeName }: Props) => {
                         (preferred_currency_code ?? 'usdc') as string
                     );
 
+                    const usdcFormattedPrice = formatPriceBetweenCurrencies(
+                        variant?.prices,
+                        preferred_currency_code ?? 'usdc',
+                        'usdc'
+                    );
+
                     const reviewCounter = product.reviews.length;
                     const totalRating = product.reviews.reduce(
                         (acc: number, review: any) => acc + review.rating,
@@ -155,6 +162,7 @@ const ProductCardGroup = ({ storeName }: Props) => {
                                 countryCode={product.countryCode}
                                 productName={product.title}
                                 productPrice={formattedPrice}
+                                usdcProductPrice={usdcFormattedPrice}
                                 currencyCode={preferred_currency_code ?? 'usdc'}
                                 imageSrc={product.thumbnail}
                                 hasDiscount={product.is_giftcard}

--- a/hamza-client/src/modules/products/components/product-group/index.tsx
+++ b/hamza-client/src/modules/products/components/product-group/index.tsx
@@ -19,6 +19,7 @@ import { getAllProducts } from '@lib/data';
 import useProductGroup from '@/zustand/products/product-group/product-group';
 import useProductFilterModal from '@/zustand/products/filter/product-filter';
 import { useSearchParams } from 'next/navigation';
+import { formatPriceBetweenCurrencies } from '@/lib/util/prices';
 
 const ProductCardGroup = ({
     columns = { base: 2, lg: 4 },
@@ -143,20 +144,11 @@ const ProductCardGroup = ({
                         preferred_currency_code as string
                     );
 
-                    let usdcProductPrice: number;
-                    let usdcFormattedPrice: string | number = '';
-                    if (preferred_currency_code === 'eth') {
-                        usdcProductPrice =
-                            variant?.prices?.find(
-                                (price: any) => price.currency_code === 'usdc'
-                            )?.amount ||
-                            variant?.prices?.[0]?.amount ||
-                            0;
-                        usdcFormattedPrice = formatCryptoPrice(
-                            usdcProductPrice ?? 0,
-                            'usdc'
-                        );
-                    }
+                    const usdcFormattedPrice = formatPriceBetweenCurrencies(
+                        variant?.prices,
+                        preferred_currency_code ?? 'usdc',
+                        'usdc'
+                    );
 
                     const reviewCounter = product.reviews.length;
                     const totalRating = product.reviews.reduce(


### PR DESCRIPTION
- refactored to usdc code in home
- applied it to store productCard

**TESTING**
- change your preferred currency to ETH 
- go to any /store page 
- view prices on card
