### PR TITLE
HAMSTR-151: Ordering of Variants on Product Details Page

### DIFF
--- a/hamza-client/src/modules/products/components/option-select/index.tsx
+++ b/hamza-client/src/modules/products/components/option-select/index.tsx
@@ -19,7 +19,11 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
    updateOption,
    title,
  }) => {
-  const filteredOptions = option.values
+  const sortedValues = [...option.values].sort((a: any, b: any) => {
+    return (a.variant_rank) - (b.variant_rank);
+  });
+
+  const filteredOptions = sortedValues
     .map((v) => v.value)
     .filter(onlyUnique);
 

--- a/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
@@ -514,10 +514,24 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                             <div className="flex flex-col gap-y-4">
                                 {(productData.options || []).map(
                                     (option: any) => {
+                                    const updatedValues = option.values.map((val: any) => {
+                                        const matchingVariant = productData.variants.find(
+                                            (v: any) => v.id === val.variant_id
+                                        );
+
+                                        return {
+                                            ...val,
+                                            variant_rank: matchingVariant?.variant_rank ?? null, 
+                                        };
+                                    });
+                                    const augmentedOption = {
+                                            ...option,
+                                            values: updatedValues,
+                                        };
                                         return (
                                             <div key={option.id}>
                                                 <OptionSelect
-                                                    option={option}
+                                                    option={augmentedOption}           
                                                     current={options[option.id]}
                                                     updateOption={updateOptions}
                                                     title={option.title}


### PR DESCRIPTION
**Change** 

1. In the product details component, for each option.values,  matching variant (using variant_id) and attach its variant_rank to that value.
2. In the OptionSelect component, we sort the updated option.values by variant_rank in ascending order

**Test**

1. Change the variant_rank value for the same product and check if the options are sorted in ascending order.