### PR TITLE
HAMSTR-228: Balance Check on Checkout

### DIFF
--- a/hamza-client/src/modules/checkout/components/payment-button/payment-handlers/escrow-multicall.ts
+++ b/hamza-client/src/modules/checkout/components/payment-button/payment-handlers/escrow-multicall.ts
@@ -145,7 +145,10 @@ export class EscrowWalletPaymentHandler implements IWalletPaymentHandler {
         for (let input of inputs) {
             let existing = output.find((o) => o.currency == input.currency);
             if (!existing) {
-                existing = { currency: input.currency, amount: BigInt(0) };
+                existing = {
+                    currency: input.currency,
+                    amount: BigInt(input.amount),
+                };
                 output.push(existing);
             } else {
                 let amt: any = existing.amount;


### PR DESCRIPTION
**Motivation:**
Insufficient balance check before checkout seems to no longer happen. When user tries to purchase with insufficient funds, the wallet should never pop up; it should be prevented with an error message. 

**Changes**
It was just a really small bug. 

**To Test**
- try checking out with an insufficient balance of ETH (less than is needed for what you're buying) with your preferred currency set to ETH
- try checkout out with an insufficient balance of some stablecoin (less than is needed for what you're buying) with your preferred currency set to that stablecoin