### PR TITLE
HAMSTR-244: Giftcard Orders not Showing

### DIFF
--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -894,7 +894,7 @@ export default class OrderService extends MedusaOrderService {
                 //set fulfillment status to delivered
                 await this.setOrderStatus(
                     order,
-                    null,
+                    OrderStatus.COMPLETED,
                     FulfillmentStatus.FULFILLED,
                     null,
                     null,


### PR DESCRIPTION
**Motivation:** A bug exists where after purchasing a gift card, it doesn't show up in any of the customer order buckets. 

**Change:**
After creating the digital-only order, it must be set to OrderStatus.COMPLETED, or else it does not go into any bucket.