### PR TITLE
Hotfix stanzo handle

### DIFF
--- a/hamza-client/src/app/[countryCode]/(main)/store/[slug]/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/store/[slug]/page.tsx
@@ -20,7 +20,7 @@ export default async function StorePage({
 }: {
     params: { slug: string };
 }) {
-    if (params.slug === 'tomato') params.slug = 'ready-cash-card';
+    if (params.slug === 'tomato') params.slug = 'onlyprints';
     return (
         <Box>
             <StoreContent params={params} />


### PR DESCRIPTION
Stanzo's links should all redirect to /onlyprints, without rewriting the url.