### PR TITLE
HAMSTR-224: GiftCard Import Improvements

### DIFF
--- a/hamza-server/src/api/admin/custom/setup/giftcards/route.ts
+++ b/hamza-server/src/api/admin/custom/setup/giftcards/route.ts
@@ -18,7 +18,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         res,
         'POST',
         '/admin/custom/setup/giftcards',
-        ['currency', 'behavior', 'sales_channel']
+        ['currency', 'behavior', 'sales_channel', 'delete']
     );
 
     await handler.handle(async () => {
@@ -30,6 +30,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         */
         let behavior = handler.inputParams.behavior;
         let salesChannelId = handler.inputParams.sales_channel;
+        let deleteFlag = handler.inputParams.delete === true;
+
         if (!behavior?.length) behavior = 'combined';
 
         if (!salesChannelId?.length) {
@@ -58,7 +60,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
             salesChannelId,
             handler.hasParam('currency') //if currency is provided; otherwise use default
                 ? handler.inputParams('currency')
-                : undefined
+                : undefined,
+            deleteFlag
         );
 
         return res.json({ products });


### PR DESCRIPTION
Motivation: Gift cards that were offered, sometimes are no longer offered. Gift cards that were offered but were deleted, should be resurrected if they come back. 

**Changes** 

Backend

Updates to import Method

- Added support for the deleteFlag parameter in the API request to manage soft deletions.
- Queried all active gift cards from the database.
- Compared incoming data from Globetopper with active gift cards to detect missing products.
- Performed batch queries to retrieve missing gift cards.
- Checked if missing products were previously soft deleted and restored them when necessary.
- If deleteFlag is enabled, compared importedProductIds with existingProducts and applied soft deletion.

Updates to productService.ts

- Create the softDeleteProduct method to mark products as deleted.
- Create  the restoreProduct method, which resets deleted_at = NULL  to restore soft-deleted products.
- Created the getSoftDeletedProductsByIds method to fetch soft-deleted products .

Modifications to route.ts (Admin API Endpoint)

- Updated the API to accept the "delete" from the request body, allowing for soft deletion control.
- Passed the deleteFlag parameter to the import method in globetopperService.


**Test**

Test 1: Soft Deleting Gift Cards

Steps:

      
     1.Duplicate an existing gift card entry in public.product.
     2.Modify columns id, external_id, and handle to create a unique record.
     3.Send an import request with { delete: true } in the request body.
     4.Execute the import-gc script.

Expected Result: The duplicated record should now have a timestamp in the deleted_at column.

Test 2: Restoring Soft-Deleted Gift Cards

Steps:

      1.Manually update the deleted_at column in public.product with a timestamp to simulate soft deletion.
      2.Execute the import-gc script.

Expected Result: The soft-deleted records should have their deleted_at column reset to NULL, restoring them as active gift cards.