### PR TITLE
Product Detail page shows store handle, not name

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/store-banner/store-banner.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/store-banner/store-banner.tsx
@@ -5,7 +5,8 @@ import { useParams } from 'next/navigation';
 import { FaCheckCircle } from 'react-icons/fa';
 
 type StoreProps = {
-    store: string;
+    storeName: string;
+    storeHandle:string;
     icon: string;
 };
 
@@ -15,7 +16,7 @@ const StoreBanner = (props: StoreProps) => {
     const [isLoading, setIsLoading] = useState(true); // State to track loading
 
     const navigateToVendor = () => {
-        router.push(`/${countryCode}/store/${props.store}`);
+        router.push(`/${countryCode}/store/${props.storeHandle}`);
     };
 
     return (
@@ -61,7 +62,7 @@ const StoreBanner = (props: StoreProps) => {
                             fontWeight="bold"
                             noOfLines={1}
                         >
-                            {props.store}
+                            {props.storeName}
                         </Text>
                         <Flex
                             display={{ base: 'none', md: 'flex' }}

--- a/hamza-client/src/modules/products/templates/index.tsx
+++ b/hamza-client/src/modules/products/templates/index.tsx
@@ -42,7 +42,8 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
         setQuantity,
     } = useProductPreview();
 
-    const [store, setStore] = useState('');
+    const [storeName, setstoreName] = useState('');
+    const [storeHandle, setstorehandle] = useState('');
     const [icon, setIcon] = useState('');
     const [selectedVariantImage, setSelectedVariantImage] = useState('');
 
@@ -81,7 +82,8 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
             try {
                 const data = await getStore(product.id as string);
                 // console.log(`Vendor: ${data}`);
-                setStore(data.handle);
+                setstoreName(data.name);
+                setstorehandle(data.handle);
                 setIcon(data.icon);
             } catch (error) {
                 console.error('Error fetching vendor: ', error);
@@ -189,7 +191,7 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
                         />
                     </Flex>
                 </Flex>
-                <StoreBanner store={store} icon={icon} />
+                <StoreBanner storeName={storeName} storeHandle={storeHandle} icon={icon} />
                 <Divider
                     color="#555555"
                     display={{ base: 'block', md: 'none' }}


### PR DESCRIPTION
Motivation: At the bottom of the product detail page, we show the store name - only we’re not showing the name, we’re showing the handle.

**Change**

- Created a new variable to handle the store name.
- Passed it to the store banner to display instead of the store handle.