### PR TITLE
Hamstr 177 incorrect display for products with exclusive variants

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
@@ -324,6 +324,33 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
         fetchCart();
     }, [countryCode]);
 
+    const getValidValuesForOption = (optionId: string): string[] => {
+        const mainOptionId = productData.options[0]?.id;
+
+        // For the main variant, show all available values.
+        if (optionId === mainOptionId) {
+            const mainOption = productData.options.find((opt: any) => opt.id === optionId);
+            return mainOption ? mainOption.values.map((val: any) => val.value) : [];
+        }
+
+        // For sub variant options, filter based on the main variant selection.
+        const mainSelection = options[mainOptionId];
+        const validValues = new Set<string>();
+        productData.variants.forEach((variant: any) => {
+            // Only consider variants that match the main variant selection.
+            const mainVariantOption = variant.options.find((opt: any) => opt.option_id === mainOptionId);
+            if (mainVariantOption && mainVariantOption.value === mainSelection) {
+                // Find the value for the current sub variant option.
+                const subVariantOption = variant.options.find((opt: any) => opt.option_id === optionId);
+                if (subVariantOption) {
+                    validValues.add(subVariantOption.value);
+                }
+            }
+        });
+
+        return Array.from(validValues);
+    };
+
     return (
         <Flex
             padding={{ base: '0', md: '2rem' }}
@@ -539,6 +566,8 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                             <div className="flex flex-col gap-y-4">
                                 {(productData.options || []).map(
                                     (option: any) => {
+                                        const validValues = getValidValuesForOption(option.id);
+
                                         const updatedValues = option.values.map(
                                             (val: any) => {
                                                 const matchingVariant =
@@ -554,8 +583,9 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                                                         matchingVariant?.variant_rank ??
                                                         null,
                                                 };
-                                            }
-                                        );
+                                            })
+                                            .filter((val: any) => validValues.includes(val.value));
+
                                         const augmentedOption = {
                                             ...option,
                                             values: updatedValues,


### PR DESCRIPTION
Motivation: For this particular case, there are two variants with 2 options each. However, for this particular case, one of the 4 possible combinations is not allowed (that variant doesn’t exist in the database). 

However, the UI assumes that all possible combinations are allowed. 


**Change**

- Created a new helper (getValidValuesForOption) that computes valid option values based on the current main option selection.
- Filtered sub-options based on the selected value of the main option.


**Test** 

  1.Select a product that has sub-variants. (e.g., Medusa T-Shirt) 
  2.In the public.product_variant table, change the title of the product (e.g., change "S / Black" to "S / Red").
  3.In the public.product_option_value table, update the value column for the variant_id corresponding to the change made in public.product_variant.
  4.Go to the product detail page.
  5.Verify that the variant and sub-variant reflect the changes.
  6.Switch to another variant to check that the sub-variant updates accordingly.
  7.Click "Add to Cart" for the modified product.
  8.Confirm in the cart that the product and variant in the Order Summary match the selected options.