### PR TITLE
HAMSTR-295-use local links for internal home anchor

### DIFF
--- a/hamza-client/src/modules/layout/templates/nav/index.tsx
+++ b/hamza-client/src/modules/layout/templates/nav/index.tsx
@@ -69,7 +69,7 @@ export default async function Nav() {
                     alignItems="center"
                 >
                     <Flex width={'100%'} alignItems="center" gap={'18px'}>
-                        <a href="/">
+                        <LocalizedClientLink href="/">
                             <Flex
                                 width={'190px'}
                                 height={'80px'}
@@ -84,7 +84,7 @@ export default async function Nav() {
                                     alt="Hamza"
                                 />
                             </Flex>
-                        </a>
+                        </LocalizedClientLink>
 
                         <NavSearchBar />
 


### PR DESCRIPTION
when clicking the sites logo, there is always a refresh.  Since its an internal link, its not necessary to use <a> tag.

**TEST**

1. Click on home icon when in other pages
2. Page should not refresh