### PR TITLE
HAMSTR-288: Phone number required

### DIFF
--- a/hamza-client/src/modules/checkout/components/address-modal/index.tsx
+++ b/hamza-client/src/modules/checkout/components/address-modal/index.tsx
@@ -418,7 +418,7 @@ const AddressModal: React.FC<AddressModalProps> = ({
                                 gap="4"
                                 flexDir={{ base: 'column', md: 'row' }}
                             >
-                                <FormControl>
+                                <FormControl isRequired>
                                     <Input
                                         placeholder="Phone Number"
                                         height={'50px'}


### PR DESCRIPTION
**Motivation:**
AirDeveloppa requires that customer orders come with a phone number. Mike would like to make this field required  in checkout.

**Changes:**
Just made phone # required. 

**To Test:**
- place items in cart 
- go to checkout 
- edit shipping address
- try to submit address with no phone number; it should be rejected

- enter phone number 
- place order successfully
- check database for correct phone number (should be in addresses table, address associated with your order)