### PR TITLE
HAMSTR-328: Google Analytics Fix

### DIFF
--- a/hamza-client/src/app/layout.tsx
+++ b/hamza-client/src/app/layout.tsx
@@ -13,6 +13,8 @@ import { Toaster } from 'react-hot-toast';
 import { Sora } from 'next/font/google';
 import Script from 'next/script';
 import FreeScoutWidget from './components/scripts/chat-widget';
+import { GoogleAnalytics } from '@next/third-parties/google'
+
 // import { GoogleTagManager } from '@next/third-parties/google';
 export const metadata: Metadata = {
     metadataBase: new URL(BASE_URL),
@@ -103,6 +105,8 @@ export default function RootLayout(props: { children: React.ReactNode }) {
                     <FreeScoutWidget />
                 </div>
             </body>
+            {/* Documentation on this problem and how to solve it: https://nextjs.org/docs/messages/next-script-for-ga*/}
+            <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || ''} />
         </html>
     );
 }


### PR DESCRIPTION
Well I just followed the nextjs guide it seems to be fine on google chrome, but I'm not setting an id... 

https://nextjs.org/docs/messages/next-script-for-ga

John says: testing this with the valid ID is key. I tested this change on staging.hamza.biz, with the true id, and it seemed to be ok.

