### PR TITLE
HAMSTR-364 vscode breakpoint debugging

### DIFF
--- a/hamza-client/package.json
+++ b/hamza-client/package.json
@@ -8,7 +8,7 @@
         "medusa-storefront"
     ],
     "scripts": {
-        "_devcomment": "This allows for debugging server components. The debugger will be attached to port 9230.  In LoadpipeSetup/market/hamza-client.code-workspace, There is a companion configuration to manage server component debug with breakpoints.  There are 2 debuggers, one for client and another for server.",
+        "_devcomment": "This allows for debugging server components. The debugger will be attached to port 9230.  In LoadpipeSetup/market/hamza-client.code-workspace, There is a companion configuration to manage server component debug with breakpoints.  There are 2 debuggers, one for client and another for server.  Both should work out of the box.",
         "dev": "NODE_OPTIONS='--inspect' next dev -p 8000 --turbo",
         "build": "next build",
         "start": "next start -p 8000",


### PR DESCRIPTION
**PROBLEM**
Most debugging has been done using console.log.  But for more complex interactions, step debugging provides better insight to surrounding data availability at "points in time".  Its not perfect in this promise type of architecture, but its still provides more insight and easier access to data.

**PRE-REQUISITE**
This implementation is for vscode, or any other vscode based ide (such as Cursor).  
You will also require debugger configuration in vscode (launch.json), which i've set one up in LoadpipeSetup/market/hamza-client.code-workspace.  If you just want to use the launch portion, just copy that and put it into a launch.json file.

**CLIENT AND SERVER COMPONENT DEBUGGING**
The configuration is set with client and server component debugging.  Since NextJS has both server and client components, debug config is different, but the stepping into code is the same between them.

**TEST**
Client Component
1. Start application
2. Setup launch.json (or workspace - whichever your using)
3. Select Run and Debug -> Next.js: debug client components
4. (optional) cmdline:  "killall -9 chrome"  - The debugger can only attach to new chrome process
5. Click the "play" button to start debugger
6. A new browser will open (should be the current profile - for logging into metamask)
7. Add a breakpoint to a client component
8. Refresh browser - vscode should stop at the breakpoint and you can step in/out...watch variables etc.

Server Component
1. Start application
2. Setup launch.json (or workspace - whichever your using)
3. Select Run and Debug -> Next.js: debug server components
4. Click the "play" button to start debugger
5. Add a breakpoint in a server component
6. Open browser and visit the page you put the breakpoint in
7. Vscode should stop at the breakpoint 
