### PR TITLE
HAMSTR-421 : React Query to Load Correct Store Products

### DIFF
--- a/hamza-client/src/modules/products/components/product-group-store/index.tsx
+++ b/hamza-client/src/modules/products/components/product-group-store/index.tsx
@@ -31,7 +31,7 @@ const ProductCardGroup = ({ storeName }: Props) => {
     const url = `${process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || 'http://localhost:9000'}/custom/store/products/category-name?store_name=${storeName}&category_name=${categoryParam}&currency_code=${preferred_currency_code ?? 'usdc'}`;
 
     const { data, error, isLoading } = useQuery({
-        queryKey: ['products', selectedCategories],
+        queryKey: ['products', storeName, selectedCategories, preferred_currency_code],
         queryFn: async () => {
             console.log('Fetching data from URL:', url);
             const response = await axios.get(url);


### PR DESCRIPTION
**Motivation:**

When users switch between different store pages, the product list remains that of the previously visited store due to an incomplete query key. The current implementation of React Query uses a cache key that doesn't include the store name or preferred currency. This causes the application to reuse stale cached data, leading to an incorrect product display. 


**Change :** 
1. Updated the React Query from ['products', selectedCategories] to include storeName and preferred_currency_code (i.e., ['products', storeName, selectedCategories, preferred_currency_code]).