### PR TITLE
HAMSTR-413: Fixed bug in multiple geo-restriction tags (1.2.3 Hotfix)

### DIFF
--- a/hamza-client/src/modules/checkout/components/cart-items/index.tsx
+++ b/hamza-client/src/modules/checkout/components/cart-items/index.tsx
@@ -46,16 +46,19 @@ const CartItems = ({
                             item?.variant?.product?.tags?.filter((t: any) =>
                                 t?.id?.startsWith('geo-restriction')
                             ) ?? [];
+                        let geoRestricted: boolean = true;
                         for (let tag of tags) {
                             if (tag?.metadata?.country) {
                                 if (
-                                    cart?.shipping_address?.country_code?.toLowerCase() !==
+                                    cart?.shipping_address?.country_code?.toLowerCase() ===
                                     tag.metadata.country.toLowerCase()
                                 ) {
-                                    restrictedVariants.push(item);
+                                    geoRestricted = false;
                                 }
                             }
                         }
+
+                        if (geoRestricted) restrictedVariants.push(item);
                     }
 
                     setRegionLockedItems(


### PR DESCRIPTION
**Motivation**
Discovered when implementing geo-restrictions for BigWater; if multiple geo-restriction tags are present for a variant, the variant gets flagged that many times. 

**Changes**
- Small UI logic change to prevent multiple flagging 

**To Test**
- Add multiple geo-restriction tags (for different countries) to the same variant 
- Add that variant to your cart
- Use a geo-restricted country in your address
- The "remove from cart" flag should come up, but should only list the restricted variant once.