### PR TITLE
HAMSTR-366: Store with Handle or Name not found

### DIFF
--- a/hamza-client/src/app/[countryCode]/(main)/store/[slug]/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/store/[slug]/page.tsx
@@ -23,6 +23,8 @@ export default async function StorePage({
 }) {
     if (params.slug?.toLowerCase() === "stanzo's%203d%20prints")
         redirect('/en/store/onlyprints');
+    if (params.slug?.toLowerCase() === 'stanzo')
+        redirect('/en/store/onlyprints');
 
     //params.slug = 'onlyprints';
     return (


### PR DESCRIPTION
**Motivation:** 
A common error showing up in the live error logs is “Store with handle or name Stanzo not found”
Indicates that there are still some links out there somewhere for /en/store/Stanzo 

**Changes:** 
made sure that this, as a one-off, just redirects to the correct url.