### PR TITLE
HAMSTR-424: Shipping One off bug

### DIFF
--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -1,12 +1,13 @@
 import { Metadata } from 'next';
 import { cookies } from 'next/headers';
-import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
 import { Flex } from '@chakra-ui/react';
 import ForceWalletConnect from '@/modules/common/components/force-wallet-connect';
 import CheckoutTemplate from '@/modules/checkout/templates';
 import { fetchCartForCheckout } from '@/app/[countryCode]/(checkout)/checkout/utils/fetch-cart-for-checkout';
 import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth';
+import getQueryClient from '@/app/query-utils/getQueryClient';
 
 export const metadata: Metadata = {
     title: 'Checkout',
@@ -14,10 +15,11 @@ export const metadata: Metadata = {
 };
 
 export default async function Checkout(params: any) {
-    const queryClient = new QueryClient();
+    const queryClient = getQueryClient();
 
     let cartId = cookies().get('_medusa_cart_id')?.value;
-    if (!cartId && params?.searchParams?.cart) cartId = params.searchParams.cart;
+    if (!cartId && params?.searchParams?.cart)
+        cartId = params.searchParams.cart;
 
     if (!cartId) {
         console.log('Cart ID not found');

--- a/hamza-client/src/app/[countryCode]/(main)/cart/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/cart/page.tsx
@@ -1,9 +1,9 @@
 import { Metadata } from 'next';
 import CartTemplate from '@/modules/cart/templates/cart-template';
 import { getHamzaCustomer } from '@/lib/server';
-import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { fetchCartForCart } from '@/app/[countryCode]/(main)/cart/utils/fetch-cart-for-cart';
-
+import getQueryClient from '@/app/query-utils/getQueryClient';
 
 // Single source of truth
 // Supports both: Checkout && Cart
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 
 export default async function Cart() {
     // SSR So make sure to create a new queryClient instance, so we don't share the same instance between multiple requests
-    const queryClient = new QueryClient();
+    const queryClient = getQueryClient();
 
     // Prefetch cart with enrichment & checkout step
     await queryClient.prefetchQuery({
@@ -37,4 +37,3 @@ export default async function Cart() {
         </HydrationBoundary>
     );
 }
-

--- a/hamza-client/src/modules/checkout/components/address-modal/index.tsx
+++ b/hamza-client/src/modules/checkout/components/address-modal/index.tsx
@@ -221,12 +221,24 @@ const AddressModal: React.FC<AddressModalProps> = ({
         } finally {
             onClose();
 
-            // alert(cart?.id);
-            // alert(preferred_currency_code);
-            queryClient.refetchQueries({
-                queryKey: ['shippingCost', cart?.id, preferred_currency_code],
-            });
+            // Ensure address update completes before invalidating queries
             await setAddresses(formPayload);
+
+            // Invalidate and refetch AFTER addresses are updated
+            await queryClient.invalidateQueries({
+                queryKey: [
+                    'shippingCost',
+                    cart?.shipping_address,
+                    preferred_currency_code,
+                ],
+            });
+            await queryClient.refetchQueries({
+                queryKey: [
+                    'shippingCost',
+                    cart?.shipping_address,
+                    preferred_currency_code,
+                ],
+            });
         }
     };
 

--- a/hamza-client/src/modules/common/components/cart-totals/index.tsx
+++ b/hamza-client/src/modules/common/components/cart-totals/index.tsx
@@ -40,11 +40,17 @@ const CartTotals: React.FC<CartTotalsProps> = ({ useCartStyle, cartId }) => {
     });
 
     const { data: shippingCost, isLoading: loading } = useQuery({
-        queryKey: ['shippingCost', cart?.id, preferred_currency_code], // Unique key per cart
+        queryKey: [
+            'shippingCost',
+            cart?.shipping_address,
+            preferred_currency_code,
+        ],
         queryFn: () => updateShippingCost(cart!.id), // Only fetch when cart exists
         enabled: !!cart?.id, // Prevents fetching if no cart ID is available
-        staleTime: 0, // Cache shipping cost for 5 minutes
+        staleTime: 0,
+        gcTime: 0, // Were not caching the shipping
     });
+    // alert(shippingCost);
 
     // Refactor: Imperative code to Declarative subset (Functional) code
     const getCartSubtotal = (


### PR DESCRIPTION
- fixed order of operations, one off bug, added query invalidation before refetch.
- using getQueryClient in Cart && Checkout (critical bug fix / shared instance prevention) 
- override default garbage collect / cache to 0 for `shipping` global queryKey