### PR TITLE
HAMSTR-679 - Setting default variant with variant_rank of 0

### DIFF
--- a/hamza-client/src/lib/schemas/product.ts
+++ b/hamza-client/src/lib/schemas/product.ts
@@ -6,7 +6,11 @@ export const ProductSchema = z.object({
     title: z.string(),
     created_at: z.string().transform((str) => new Date(str)),
     updated_at: z.string().transform((str) => new Date(str)),
-    deleted_at: z.string().nullable().transform((str) => (str ? new Date(str) : null)),    subtitle: z.string().optional().nullable(),
+    deleted_at: z
+        .string()
+        .nullable()
+        .transform((str) => (str ? new Date(str) : null)),
+    subtitle: z.string().optional().nullable(),
     handle: z.string().optional().nullable(),
     description: z.string().optional(),
     thumbnail: z
@@ -32,7 +36,7 @@ export const ProductSchema = z.object({
                 url: z.string().url({ message: 'Invalid image URL' }),
                 id: z.string(),
                 fileName: z.string(),
-            }),
+            })
         )
         .optional()
         .default([]),
@@ -55,7 +59,7 @@ export const ProductSchema = z.object({
                     })
                     .optional()
                     .nullable(),
-            }),
+            })
         )
         .optional()
         .nullable(), // Ensure categories can be optional and nullable
@@ -67,7 +71,10 @@ export const ProductSchema = z.object({
             title: z.string(),
             created_at: z.string().transform((str) => new Date(str)),
             updated_at: z.string().transform((str) => new Date(str)),
-            deleted_at: z.string().nullable().transform((str) => (str ? new Date(str) : null)),
+            deleted_at: z
+                .string()
+                .nullable()
+                .transform((str) => (str ? new Date(str) : null)),
             sku: z.string().nullable(),
             inventory_quantity: z.number(),
             variant_rank: z.number(),
@@ -79,12 +86,20 @@ export const ProductSchema = z.object({
                 .array(
                     z.object({
                         id: z.string(),
-                        created_at: z.string().transform((str) => new Date(str)),
-                        updated_at: z.string().transform((str) => new Date(str)),
-                        deleted_at: z.string().nullable().transform((str) => (str ? new Date(str) : null)),
+                        created_at: z
+                            .string()
+                            .transform((str) => new Date(str)),
+                        updated_at: z
+                            .string()
+                            .transform((str) => new Date(str)),
+                        deleted_at: z
+                            .string()
+                            .nullable()
+                            .transform((str) => (str ? new Date(str) : null)),
                         value: z.string(),
                         option_id: z.string(),
                         variant_id: z.string(),
+                        variant_rank: z.number(),
                         metadata: z.any().nullable(),
                     })
                 )
@@ -100,7 +115,7 @@ export const ProductSchema = z.object({
                         max_quantity: z.number().nullable(),
                         price_list_id: z.string().nullable(),
                         region_id: z.string().nullable(),
-                    }),
+                    })
                 )
                 .optional()
                 .default([]),
@@ -123,7 +138,7 @@ export const ProductSchema = z.object({
                     imgUrl: z.string().url().optional(),
                 })
                 .nullable(),
-        }),
+        })
     ),
 });
 

--- a/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/summary/preview-checkout.tsx
@@ -248,7 +248,7 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                         selectedProductVariant.prices,
                         isEthCurrency
                             ? 'eth'
-                            : preferred_currency_code ?? 'usdc'
+                            : (preferred_currency_code ?? 'usdc')
                     );
 
                     // Update USD price if the preferred currency is 'eth'
@@ -306,13 +306,25 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
     // it sets the initial options to the first value of each option
     useEffect(() => {
         if (productData?.options) {
-            const initialOptions = productData.options.reduce(
-                (acc: any, option: any) => {
-                    // Assuming each option has a 'values' array and each 'value' object has a 'value' property
-                    const firstValue = option.values?.[0]?.value;
-                    if (firstValue) {
-                        acc[option.id] = firstValue;
+            // Find variant with lowest variant_rank
+            const lowestRankVariant = productData.variants.reduce(
+                (lowest: any, current: any) => {
+                    if (
+                        !lowest ||
+                        (current.variant_rank !== null &&
+                            (lowest.variant_rank === null ||
+                                current.variant_rank < lowest.variant_rank))
+                    ) {
+                        return current;
                     }
+                    return lowest;
+                }
+            );
+
+            // Create initialOptions from the lowest rank variant's options
+            const initialOptions = lowestRankVariant.options.reduce(
+                (acc: any, opt: any) => {
+                    acc[opt.option_id] = opt.value;
                     return acc;
                 },
                 {}
@@ -458,10 +470,7 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                     >
                         Listing Price
                     </Heading>
-                    <Flex
-                        alignItems="center"
-                        gap={1}
-                    >
+                    <Flex alignItems="center" gap={1}>
                         <Box color="primary.green.900">
                             <Image
                                 src={shieldIcon}
@@ -470,16 +479,20 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                                 height={12}
                             />
                         </Box>
-                        <Text fontSize={'18px'} fontWeight="normal" color="primary.green.900">
+                        <Text
+                            fontSize={'18px'}
+                            fontWeight="normal"
+                            color="primary.green.900"
+                        >
                             Escrow
                         </Text>
-                        { /* <Box as="span" cursor="pointer" color="white"> */ }
-                         { /*    <Box as="svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"> */ }
-                        { /*         <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" /> */ }
-                         { /*        <path d="M9 9a3 3 0 1 1 4 2.829 1 1 0 0 0-1 1V14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" /> */ }
-                         { /*        <circle cx="12" cy="17" r="1" fill="currentColor" /> */ }
-                       { /*      </Box> */ }
-                       { /*  </Box> */}
+                        {/* <Box as="span" cursor="pointer" color="white"> */}
+                        {/*    <Box as="svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"> */}
+                        {/*         <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" /> */}
+                        {/*        <path d="M9 9a3 3 0 1 1 4 2.829 1 1 0 0 0-1 1V14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" /> */}
+                        {/*        <circle cx="12" cy="17" r="1" fill="currentColor" /> */}
+                        {/*      </Box> */}
+                        {/*  </Box> */}
                     </Flex>
                 </Flex>
                 <Flex
@@ -660,8 +673,9 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                 display={{ base: 'block', md: 'none' }}
                 mt="1rem"
             />
-            {/* Variants */}
+
             <Flex width={'100%'} flexDirection={'column'} mt="1rem">
+                {/* Variants */}
                 <div>
                     {productData &&
                         productData.variants &&
@@ -752,6 +766,7 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
                             </div>
                         )}
                 </div>
+                {/* Variants: end */}
 
                 <QuantityButton />
 


### PR DESCRIPTION
Problem:
default variant was being set as the first item in the result set for variant.options, which is not based on any sorting.

Fix:
setting default based on variant_rank with lowest number.

**Test:**
1. Visit a product with multiple variants
2. Determine which variant has variant_rank of 0
3. See if the default selected item is the item with variant rank of 0
