### PR TITLE
HAMSTR-774 : Cancel Payment button sliding off on mobile

### DIFF
--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -395,11 +395,21 @@ const OrderProcessing = ({
             <Box bg="gray.900" p={6} borderRadius="xl">
                 <VStack spacing={6} align="stretch">
                     {/* Payment Header */}
-                    <HStack justify="space-between">
+                    <Stack
+                        direction={{ base: 'column', md: 'row' }}
+                        justify={{ base: 'flex-start', md: 'space-between' }}
+                        align={{ base: 'flex-start', md: 'center' }}
+                        spacing={{ base: 4, md: 0 }}
+                    >
                         <Text fontSize="2xl" color="white" fontWeight="bold">
                             Payment Status
                         </Text>
-                        <HStack spacing={3}>
+                        <Stack
+                            direction={{ base: 'column', sm: 'row' }}
+                            spacing={3}
+                            align={{ base: 'flex-start', sm: 'center' }}
+                            w={{ base: 'full', md: 'auto' }}
+                        >
                             <Box
                                 bg={
                                     currentStatus === 'expired'
@@ -455,12 +465,14 @@ const OrderProcessing = ({
                                         isDisabled={
                                             isCanceling || !cancelEnabled
                                         }
+                                        w={{ base: 'full', sm: 'auto' }}
+                                        maxW={{ base: '200px', sm: 'none' }}
                                     >
                                         Cancel Payment
                                     </Button>
                                 )}
-                        </HStack>
-                    </HStack>
+                        </Stack>
+                    </Stack>
 
                     <Text color="gray.300">Cart ID: {cartId}</Text>
 


### PR DESCRIPTION
Changes:

1. Replace HStack with responsive Stack in payment header section
2. Add mobile-responsive layout for Cancel Payment button with full-width on mobile

Test:

1. Mobile checkout with "Pay with External" - verify Cancel Payment button fully visible
2. Desktop view - confirm original layout maintained