### PR TITLE
HAMSTR-807 : In shop page, the maximum price range starts at $5 million

### DIFF
--- a/hamza-client/src/app/sitemap.ts
+++ b/hamza-client/src/app/sitemap.ts
@@ -10,7 +10,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         // Fetch all data 
         const [stores, productsData, categories] = await Promise.all([
             getStores(),
-            getAllProducts(['all'], 5000000, 0, 'usdc', 1000, 0), 
+            getAllProducts(['all'], 30000, 0, 'usdc', 1000, 0), 
             listCategories()
         ])
 

--- a/hamza-client/src/lib/server/index.ts
+++ b/hamza-client/src/lib/server/index.ts
@@ -255,7 +255,7 @@ export async function getWishlist(customer_id: string) {
 // Get all home products by default
 export async function getAllProducts(
     categorySelect: string[] | null = ['all'],
-    priceHigh: number = 5000000,
+    priceHigh: number = 30000,
     priceLow: number = 0,
     currencyCode: string = 'usdc',
     limit: number = 24,

--- a/hamza-client/src/modules/categories/components/category-sidebar/index.tsx
+++ b/hamza-client/src/modules/categories/components/category-sidebar/index.tsx
@@ -353,7 +353,7 @@ const CategorySidebar: React.FC<CategorySidebarProps> = ({
                                         value={rangeUpper}
                                         onChange={handlePriceChange}
                                         min={0}
-                                        max={5000}
+                                        max={30000}
                                         step={1}
                                         colorScheme="green"
                                     >

--- a/hamza-client/src/modules/categories/index.tsx
+++ b/hamza-client/src/modules/categories/index.tsx
@@ -124,7 +124,7 @@ const CategoryTemplate = ({ category }: ShopTemplateProps) => {
         const priceLo = searchParams.get('price_lo');
 
         const lowerValue = priceLo ? parseInt(priceLo, 10) : 0;
-        const upperValue = priceHi ? parseInt(priceHi, 10) : 5000000;
+        const upperValue = priceHi ? parseInt(priceHi, 10) : 30000;
 
         setRangeLower(lowerValue);
         setRangeUpper(upperValue);

--- a/hamza-client/src/modules/shop/components/desktop-side-filter/range-slider.tsx
+++ b/hamza-client/src/modules/shop/components/desktop-side-filter/range-slider.tsx
@@ -78,7 +78,7 @@ const RangeSliderComponent: React.FC<RangeSliderProps> = ({
                         Minimum
                     </Text>
                     <Text fontSize="18px" color="white" lineHeight="1">
-                        USD {range[0]}
+                        USD {range[0].toLocaleString()}
                     </Text>
                 </Flex>
                 <Divider
@@ -103,7 +103,7 @@ const RangeSliderComponent: React.FC<RangeSliderProps> = ({
                         Maximum
                     </Text>
                     <Text fontSize="18px" color="white" lineHeight="1">
-                        USD {range[1]}
+                        USD {range[1].toLocaleString()}
                     </Text>
                 </Flex>
             </Flex>

--- a/hamza-client/src/modules/shop/components/mobile-filter-modal/components/range-slider-modal.tsx
+++ b/hamza-client/src/modules/shop/components/mobile-filter-modal/components/range-slider-modal.tsx
@@ -87,7 +87,7 @@ const RangeSliderModal: React.FC<RangeSliderProps> = ({ range, setRange }) => {
                         color="white"
                         lineHeight="1"
                     >
-                        USD {range[0]}
+                        USD {range[0].toLocaleString()}
                     </Text>
                 </Flex>
                 <Divider
@@ -125,7 +125,7 @@ const RangeSliderModal: React.FC<RangeSliderProps> = ({ range, setRange }) => {
                         color="white"
                         lineHeight="1"
                     >
-                        USD {range[1]}
+                        USD {range[1].toLocaleString()}
                     </Text>
                 </Flex>
             </Flex>

--- a/hamza-client/src/modules/shop/index.tsx
+++ b/hamza-client/src/modules/shop/index.tsx
@@ -94,7 +94,7 @@ const ShopTemplate = ({ category }: ShopTemplateProps) => {
         const priceLo = searchParams.get('price_lo');
 
         const lowerValue = priceLo ? parseInt(priceLo, 10) : 0;
-        const upperValue = priceHi ? parseInt(priceHi, 10) : 5000000;
+        const upperValue = priceHi ? parseInt(priceHi, 10) : 30000;
 
         setRangeLower(lowerValue);
         setRangeUpper(upperValue);

--- a/hamza-client/src/zustand/products/filter/use-unified-filter-store.ts
+++ b/hamza-client/src/zustand/products/filter/use-unified-filter-store.ts
@@ -9,7 +9,7 @@ interface CategoryItem {
 type RangeType = [number, number];
 
 export const FILTER_PRICE_RANGE_MIN = 0;
-export const FILTER_PRICE_RANGE_MAX = 5000;
+export const FILTER_PRICE_RANGE_MAX = 30000;
 
 interface UnifiedFilterState {
     // Category filtering


### PR DESCRIPTION
**Changes:**

  1. Reduced maximum price range from $5M to $30K across all components
  2. Updated filter store constant from 5000 to 30000
  3. Fixed price display formatting with proper comma separators

  **Test:**

  1. Clear browser cache/localStorage for localhost:8000
  2. Navigate to /shop page and verify price slider shows max $30,000
  3. Test price filtering works correctly up to $30K limit
  4. Verify mobile and desktop filter displays show proper formatting
