### PR TITLE
HAMSTR-809 : 301 redirect /category/giftcards to /category/gift-cards

### DIFF
--- a/hamza-client/src/app/[countryCode]/(main)/category/[handle]/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/category/[handle]/page.tsx
@@ -16,6 +16,10 @@ type Params = {
 export default function CategoryShopPage({ params }: Params) {
     const { handle, countryCode } = params;
 
+    if (handle?.toLowerCase() === 'giftcards') {
+        redirect(`/${countryCode}/category/gift-cards`);
+    }
+
     const decodedHandle = decodeURIComponent(handle);
     const normalizedHandle = decodedHandle.trim().replace(/[\s_]+/g, '-').toLowerCase();
 


### PR DESCRIPTION
  Changes:

  1. Redirect from `/category/giftcards` to `/category/gift-cards` in CategoryShopPage component

  Test:

  1. Navigate to `/en/category/giftcards` - should redirect to `/en/category/gift-cards`
  2. Verify normal category pages still work without breaking existing functionality