### PR TITLE
HAMSTR-805: Cart crash fix

### DIFF
--- a/hamza-client/package.json
+++ b/hamza-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hamza-client",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "private": true,
     "author": "Garo Nazarian, Beau Troxclair, Jonny Bajada, Karan Chugh, Chris Li, John R. Kosinski, Gun",
     "description": "Hamza Web Client",

--- a/hamza-client/src/lib/server/index.ts
+++ b/hamza-client/src/lib/server/index.ts
@@ -542,11 +542,16 @@ export async function getStoreIdByName(store_name: string) {
 
 export async function setCurrency(
     preferred_currency: string,
-    customer_id: string
+    customer_id: string,
+    cart_id?: string
 ) {
+    if (!cart_id) {
+        cart_id = cookies().get('_medusa_cart_id')?.value;
+    }
     return putSecure('/custom/customer/preferred-currency', {
         customer_id,
         preferred_currency,
+        cart_id,
     });
 }
 

--- a/hamza-client/src/modules/account/components/profile/components/profile-form/components/profile-currency.tsx
+++ b/hamza-client/src/modules/account/components/profile/components/profile-form/components/profile-currency.tsx
@@ -57,6 +57,7 @@ const ProfileCurrency: React.FC<ProfileCurrencyProps> = ({
                 console.log(err);
             });
         }
+
         setCustomerPreferredCurrency(currencyCode);
         await setCurrency(currencyCode, customerId);
 

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -415,7 +415,7 @@ const CryptoPaymentButton = ({
     const switchToBitcoin = async () => {
         try {
             setCustomerPreferredCurrency('btc');
-            await setCurrency('btc', authData.customer_id);
+            await setCurrency('btc', authData.customer_id, cart.id);
         } catch (error) {
             console.error('Error updating currency:', error);
         }


### PR DESCRIPTION
**Motivation**
We have a mysterious problem in which the site seems to be freezing/crashing when certain actions are taken in the cart. But it's intermittent and maybe not easy to reproduce. 

--- 

**Detail** 
We had a problem that looked similar to this early on around the time of the first release. That one was locking up the database on the call to lineItemRepository._save in CartService.retrieve (which is called alot). I fixed it by reducing the need to keep calling lineItemRepository._save in that method.

--- 

**Changes**
I'm not able to reproduce this error any longer. I made an improvement to the original fix, by changing the call to lineItemRepository._save with lineItemRepository._update (and only updating currency_code and unit_price in that update). It seems to be an improvement. This is called when saveLineItems is passed into CartService.retrieve, and I'm now passing that from PUT /custom/customer/preferred-currency route, under certain conditions. 

--- 

**To Test**
- Test in conjunction with the corresponding back-end change https://github.com/LoadPipe/hamza-backend/pull/122. 
- Do what you do to reproduce this issue; note whether it's still reproducible without the fix, and with the fix.