### PR TITLE
HAMSTR-818 : Ordering of Subcategories

### DIFF
--- a/hamza-client/src/lib/server/index.ts
+++ b/hamza-client/src/lib/server/index.ts
@@ -1632,6 +1632,14 @@ export async function getFeaturedStores(
     }
 }
 
-export async function getSubcategories(parent_category_handle: string) {
-    return get('/custom/category/subcategories', { parent_category_handle });
+export async function getSubcategories(
+    parent_category_handle: string,
+    sortBy?: string,
+    sortDirection?: string
+) {
+    const params: any = { parent_category_handle };
+    if (sortBy) params.sortBy = sortBy;
+    if (sortDirection) params.sortDirection = sortDirection;
+    
+    return get('/custom/category/subcategories', params);
 }

--- a/hamza-client/src/modules/categories/index.tsx
+++ b/hamza-client/src/modules/categories/index.tsx
@@ -68,7 +68,7 @@ const CategoryTemplate = ({ category }: ShopTemplateProps) => {
         queryFn: async () => {
             if (!category) return null;
             const [subcategoriesResponse, productsResponse] = await Promise.all([
-                getSubcategories(category),
+                getSubcategories(category, 'productCount', 'desc'),
                 getAllProducts(
                     [category],
                     0, 


### PR DESCRIPTION
**Motivation**

We display subcategories of gift-cards (or any category that has child categories) on the /category page; I don’t know what they are ordered by though. 

  **Changes:**

  1. Update getSubcategories function to accept sorting parameters
  2. Pass productCount and desc when fetching child categories in CategoryTemplate

  **Test:**

  1. Navigate to any category page with subcategories
  2. Verify subcategories are displayed sorted by product count (highest first)

