### PR TITLE
HAMSTR-781: Cart Timezone and Email Dates

### DIFF
--- a/hamza-client/src/app/components/providers/rainbowkit/rainbow-provider.tsx
+++ b/hamza-client/src/app/components/providers/rainbowkit/rainbow-provider.tsx
@@ -164,6 +164,13 @@ export function RainbowWrapper({ children }: { children: React.ReactNode }) {
         console.log(authData.wallet_address);
     }, [authData.wallet_address]);
 
+    useEffect(() => {
+        //get timezone
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        Cookies.set('_timezone', timezone);
+    }, []);
+
     const walletSignature = createAuthenticationAdapter({
         getNonce: async () => {
             const nonce = await getNonce();

--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -43,7 +43,8 @@ export async function getOrSetCart(countryCode: string) {
     const region_id = region.id;
 
     if (!cart) {
-        cart = await createCart({ region_id }).then((res) => res);
+        const timezone = cookies().get('_timezone')?.value;
+        cart = await createCart({ region_id, timezone }).then((res) => res);
         cart && cookies().set('_medusa_cart_id', cart.id);
         revalidateTag('cart');
         if (cart) await createPaymentSessions(cart?.id);


### PR DESCRIPTION
**Motivation**
In the browser (e.g. the thank you page), if we show the order date/time, the frontend can handle this & translate it to the customer’s TZ. In an email it’s not that simple though. 

--- 

**Changes** 
The way I went with this is that I decided to add a new column to the cart, called 'timezone', and it holds the customer's timezone as reported by the frontend in the form 'Asia/Bangkok'. When the emails are generated, the order date is translated with moment-timezone to get the correct order date in the customer's alleged timezone. 

- Getting customer timezone in frontend, passing to /custom/cart route, where createCart is called. 

---

**To Test**
- Locally run ALTER table cart add column timezone character varying NULL;
- Test in conjunction with https://github.com/LoadPipe/hamza-backend/pull/125
- Create a new cart (make sure it's a new cart, not a cart already attached to your customer) 
- Check the database to see that the timezone column of cart table has a correct value 
- Place a breakpoint or console.log at the two places in Hamza-backend/hamza-server where it says "orderDate = cart.timezone  ? moment.tz ...etc..." and ensure that the resulting date has the correct timezone
- Complete an order 

