### PR TITLE
HAMSTR-874: Minified React Error

### DIFF
--- a/hamza-client/src/app/error.tsx
+++ b/hamza-client/src/app/error.tsx
@@ -65,7 +65,11 @@ export default function Error({ error, reset }: ErrorPageProps) {
 
                     <Flex flexDir={'column'}>
                         <Text fontSize={'32px'} fontWeight="bold">
-                            {error ? error : 'Something went wrong'}
+                            {error
+                                ? typeof error === 'object'
+                                    ? 'Something went wrong'
+                                    : error
+                                : 'Something went wrong'}
                         </Text>
                     </Flex>
 


### PR DESCRIPTION

**Description**
What happens is: 

on the generic error page /src/app/error.tsx, the line {error ? error : 'Something went wrong'} 

fails if the ‘error’ is an object and not a string. 

It causes the error page itself to crash with minified react error

**Changes**
Changed the way that the error object is handled on the global error pages